### PR TITLE
Fix issue: Remember user theme preference

### DIFF
--- a/ui/src/builder/BuilderEditor.vue
+++ b/ui/src/builder/BuilderEditor.vue
@@ -156,7 +156,8 @@ const editorContainer: Ref<HTMLElement> = ref(null);
 const editorDisabled: Ref<boolean> = ref(false);
 let editor: monaco.editor.IStandaloneCodeEditor = null;
 
-const theme: Ref<string> = ref("vs-light");
+const theme: Ref<string> = ref(localStorage.getItem("currentTheme") || "vs-light");
+
 const isLogActive: Ref<boolean> = ref(ssbm.getLogEntryCount() > 0);
 const isCodeSaved: Ref<boolean> = ref(ss.getSavedCode() === ss.getRunCode());
 const sessionTimestamp: ComputedRef<number> = computed(() => ss.getSessionTimestamp());
@@ -291,6 +292,8 @@ const toggleTheme = () => {
 		theme.value = "vs-light";
 	}
 
+	localStorage.setItem("currentTheme", theme.value);
+	
 	editor.updateOptions({
 		theme: theme.value,
 	});


### PR DESCRIPTION
## Pull Request: Fix Editor Theme Preference (#115)
Issue #115
**Description:**
This pull request addresses and resolves issue #115, which concerns the editor's inability to remember the user's choice of theme preference between sessions.

**Changes Made:**
- Implemented a solution to store the user's theme preference in local storage.
