### PR TITLE
compile python user code before running it to allow interactive debugging

### DIFF
--- a/src/streamsync/app_runner.py
+++ b/src/streamsync/app_runner.py
@@ -281,8 +281,10 @@ class AppProcess(multiprocessing.Process):
         if streamsyncuserapp is None:
             raise ValueError("Couldn't find app module (streamsyncuserapp).")
 
+        code_path = os.path.join(self.app_path, "main.py")
         with redirect_stdout(io.StringIO()) as f:
-            exec(self.run_code, streamsyncuserapp.__dict__)
+            code = compile(self.run_code, code_path, "exec")
+            exec(code, streamsyncuserapp.__dict__)
         captured_stdout = f.getvalue()
 
         if captured_stdout:

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -173,7 +173,6 @@ class TestAppRunner:
         si_res = await ar.dispatch_message(None, si)
         mail = list(si_res.payload.model_dump().get("mail"))
 
-        assert mail[0].get(
-            "payload").get("message") == "188542\n"
+        assert mail[0].get("payload").get("message") == "188542\n"
 
         ar.shut_down()


### PR DESCRIPTION
solve #137 

This PR implements support for the python debugger. This allows you to add a breakpoint in the code and explore the running context.

I didn't have to introduce new tests. There was already a test that cover



The file name appears in error messages when the user changes the python code and breaks it.

![image](https://github.com/streamsync-cloud/streamsync/assets/159559/95634765-f2a8-4525-a1ef-0d85cff2b214)
