### PR TITLE
load a javascript script with import_script as documented

### DIFF
--- a/docs/docs/frontend-scripts.md
+++ b/docs/docs/frontend-scripts.md
@@ -12,7 +12,7 @@ The following code imports a module during event handling.
 
 ```py
 def handle_click(state):
-    state.import_script("my_script", "/static/script.js")
+    state.import_frontend_module("my_script", "/static/mymodule.js")
 ```
 
 If you want the module to be imported during initialisation, use the initial state.
@@ -22,7 +22,7 @@ initial_state = ss.init_state({
     "counter": 1
 })
 
-initial_state.import_script("my_script", "/static/script.js")
+initial_state.import_frontend_module("my_script", "/static/mymodule.js")
 ```
 
 ::: tip Use versions to avoid caching
@@ -52,8 +52,26 @@ The following event handler triggers the frontend function defined in the sectio
 
 ```py
 def handle_click(state):
-    state.call_frontend_function("myscript", "sendAlert", ["Bob"])
+    state.call_frontend_function("mymodule", "sendAlert", ["Bob"])
 ```
+
+## Import a javscript script
+
+Streamsync can also import legacy javascripts. These are imported via the report's `import_script` method. This method takes two arguments. The first, `script_key` is the identifier used to import the script. The second, `path` is the path to the javascript file. The specified path must be available to the frontend, so storing it in your application's `./static` folder is recommended.
+
+```py
+initial_state = ss.init_state({
+    "counter": 1
+})
+
+initial_state.import_script("my_script", "/static/script.js")
+```
+
+::: warning
+Importing scripts is useful to import library that does not support ES6 module.
+
+If you write your own code, it is better to use ES6 modules.
+:::
 
 ## Frontend core
 

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -387,6 +387,21 @@ class StreamsyncState():
             "path": path
         })
 
+    def import_script(self, script_key: str, path: str) -> None:
+        """
+        imports the content of a script into the page
+
+        >>> initial_state = ss.init_state({
+        >>>     "counter": 1
+        >>> })
+        >>>
+        >>> initial_state.import_script("my_script", "/static/script.js")
+        """
+        self.add_mail("importScript", {
+            "scriptKey": script_key,
+            "path": path
+        })
+
     def import_frontend_module(self, module_key: str, specifier: str) -> None:
         self.add_mail("importModule", {
             "moduleKey": module_key,

--- a/ui/src/core_components/CoreRoot.vue
+++ b/ui/src/core_components/CoreRoot.vue
@@ -267,7 +267,7 @@ function addMailSubscriptions() {
 			importStylesheet(stylesheetKey, path);
 		}
 	);
-  ss.addMailSubscription(
+	ss.addMailSubscription(
 		"importScript",
 		({scriptKey, path}:{scriptKey: string, path: string}) => {
 			importScript(scriptKey, path);

--- a/ui/src/core_components/CoreRoot.vue
+++ b/ui/src/core_components/CoreRoot.vue
@@ -199,6 +199,21 @@ async function importStylesheet(stylesheetKey: string, path: string) {
     document.head.appendChild(el);
 }
 
+async function importScript(scriptKey: string, path: string) {
+	const req = await fetch(path);
+	if (req.status > 399) {
+		console.warn(`Couldn't import script at "${path}".`);
+		return;
+	}
+	const existingEl = document.querySelector(`[data-streamsync-script-key="${scriptKey}"]`);
+	existingEl?.remove();
+	const el = document.createElement("script");
+	el.dataset.streamsyncScriptKey = scriptKey;
+	const scriptText = await req.text();
+    el.textContent = scriptText;
+    document.head.appendChild(el);
+}
+
 async function importModule(moduleKey: string, specifier: string) {
 	importedModulesSpecifiers[moduleKey] = specifier;
 	await import(/* @vite-ignore */specifier);
@@ -250,6 +265,12 @@ function addMailSubscriptions() {
 		"importStylesheet",
 		({stylesheetKey, path}:{stylesheetKey: string, path: string}) => {
 			importStylesheet(stylesheetKey, path);
+		}
+	);
+  ss.addMailSubscription(
+		"importScript",
+		({scriptKey, path}:{scriptKey: string, path: string}) => {
+			importScript(scriptKey, path);
 		}
 	);
 	ss.addMailSubscription(


### PR DESCRIPTION
loads a javascript script as specified in the documentation.

https://www.streamsync.cloud/frontend-scripts.html#importing-an-es6-module

![image](https://github.com/streamsync-cloud/streamsync/assets/159559/765d1977-ef1f-43c7-9786-501091ab8512)

*This PR may be inappropriate. There may not be the will to offer this feature. I recommend keeping at least the correction on the frontend script section.*