### PR TITLE
load stylesheet and javascript script from remote location

### DIFF
--- a/docs/docs/frontend-scripts.md
+++ b/docs/docs/frontend-scripts.md
@@ -71,6 +71,20 @@ initial_state.import_script("my_script", "/static/script.js")
 Importing scripts is useful to import libraries that don't support ES6 modules. When possible, use ES6 modules. The `import_script` syntax is only used for side effects; you'll only be able to call functions from the backend using modules that have been previously imported via `import_frontend_module`.  
 :::
 
+## Importing a script or stylesheet from a URL
+
+Streamsync can also import scripts and stylesheets from URLs. This is useful for importing libraries from CDNs. The `import_script` and `import_stylesheet` methods take a `url` argument, which is the URL to the script or stylesheet.
+
+```python
+initial_state = ss.init_state({
+    "my_app": {
+        "title": "My App"
+    },
+})
+
+initial_state.import_script("lodash", "https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.js")
+```
+
 ## Frontend core
 
 You can access Streamsync's frontend core via `globalThis.core`, unlocking all sorts of functionality. Notably, you can use `getUserState()` to get values from state.

--- a/ui/src/core_components/CoreRoot.vue
+++ b/ui/src/core_components/CoreRoot.vue
@@ -185,33 +185,23 @@ function handleHashChange() {
 }
 
 async function importStylesheet(stylesheetKey: string, path: string) {
-	const req = await fetch(path);
-	if (req.status > 399) {
-		console.warn(`Couldn't import stylesheet at "${path}".`);
-		return;
-	}
 	const existingEl = document.querySelector(`[data-streamsync-stylesheet-key="${stylesheetKey}"]`);
 	existingEl?.remove();
-	const el = document.createElement("style");
+	const el = document.createElement("link");
 	el.dataset.streamsyncStylesheetKey = stylesheetKey;
-	const cssText = await req.text();
-    el.textContent = cssText;
-    document.head.appendChild(el);
+  el.setAttribute('href', path)
+  el.setAttribute("rel", "stylesheet");
+  document.head.appendChild(el);
 }
 
 async function importScript(scriptKey: string, path: string) {
-	const req = await fetch(path);
-	if (req.status > 399) {
-		console.warn(`Couldn't import script at "${path}".`);
-		return;
-	}
 	const existingEl = document.querySelector(`[data-streamsync-script-key="${scriptKey}"]`);
 	existingEl?.remove();
 	const el = document.createElement("script");
 	el.dataset.streamsyncScriptKey = scriptKey;
-	const scriptText = await req.text();
-    el.textContent = scriptText;
-    document.head.appendChild(el);
+  el.src = path;
+  el.setAttribute("rel", "modulepreload");
+  document.head.appendChild(el);
 }
 
 async function importModule(moduleKey: string, specifier: string) {


### PR DESCRIPTION
```python
initial_state = ss.init_state({
    "my_app": {
        "title": "My App"
    },
})

initial_state.import_stylesheet("reset-css", "https://cdn.jsdelivr.net/npm/reset-css@5.0.2/reset.min.css")
initial_state.import_stylesheet("theme", "/static/main.css")
initial_state.import_script('tailwind', "https://cdn.tailwindcss.com")
```