### PR TITLE
pagination component for repeater and dataframe

### DIFF
--- a/apps/hello/main.py
+++ b/apps/hello/main.py
@@ -64,7 +64,7 @@ def _generate_random_df():
 
 def _get_main_df():
     main_df = pd.read_csv("assets/main_df.csv")
-    return main_df.iloc[:10]
+    return main_df
 
 def _get_highlighted_members():
     sample_df = _get_main_df().sample(3).set_index("name", drop=False)

--- a/apps/hello/ui.json
+++ b/apps/hello/ui.json
@@ -270,7 +270,7 @@
                 "width": "1",
                 "isCollapsible": "",
                 "startCollapsed": "",
-                "horizontalAlignment": "center"
+                "contentHAlign": "center"
             },
             "parentId": "fb22acfc-cdb5-44b6-9e97-76c3a51a8fff",
             "position": 2
@@ -367,7 +367,7 @@
             "id": "09ddb2da-6fa3-4157-8da3-4d5d44a6a58d",
             "type": "horizontalstack",
             "content": {
-                "alignment": "left"
+                "contentHAlign": "start"
             },
             "parentId": "85120b55-69c6-4b50-853a-bbbf73ff8121",
             "position": 0
@@ -591,7 +591,7 @@
             "content": {
                 "width": "1",
                 "verticalAlignment": "",
-                "horizontalAlignment": ""
+                "contentHAlign": ""
             },
             "parentId": "b9cb10e5-1ead-448b-afcc-909e23afb72a",
             "position": 0
@@ -843,7 +843,7 @@
             "id": "9bb8a686-7013-4af7-a89e-d89c7754120d",
             "type": "horizontalstack",
             "content": {
-                "alignment": "left"
+                "contentHAlign": "start"
             },
             "parentId": "771dc336-69b2-400e-9ea3-e881e2332c9d",
             "position": 2,
@@ -910,23 +910,6 @@
             "handlers": {
                 "click": "handle_story_download"
             },
-            "visible": true
-        },
-        "65y0txmxyzdiskun": {
-            "id": "65y0txmxyzdiskun",
-            "type": "pagination",
-            "content": {
-                "page": "4",
-                "pageSize": "25",
-                "totalItems": "100",
-                "pageSizeOptions": "",
-                "pageSizeShowAll": "no",
-                "jumpTo": "no",
-                "urlParam": "yopa"
-            },
-            "parentId": "9bb8a686-7013-4af7-a89e-d89c7754120d",
-            "position": 2,
-            "handlers": {},
             "visible": true
         },
         "e1ax8ctt8lrao0e4": {

--- a/apps/hello/ui.json
+++ b/apps/hello/ui.json
@@ -351,7 +351,7 @@
                 "name": "Timer"
             },
             "parentId": "ee919cd6-8153-4f34-8c6a-bfc1153df360",
-            "position": 3
+            "position": 4
         },
         "db4c66d6-1eb7-44d3-a2d4-65d0b3e5cf12": {
             "id": "db4c66d6-1eb7-44d3-a2d4-65d0b3e5cf12",
@@ -909,6 +909,88 @@
             "position": 1,
             "handlers": {
                 "click": "handle_story_download"
+            },
+            "visible": true
+        },
+        "65y0txmxyzdiskun": {
+            "id": "65y0txmxyzdiskun",
+            "type": "pagination",
+            "content": {
+                "page": "4",
+                "pageSize": "25",
+                "totalItems": "100",
+                "pageSizeOptions": "",
+                "pageSizeShowAll": "no",
+                "jumpTo": "no",
+                "urlParam": "yopa"
+            },
+            "parentId": "9bb8a686-7013-4af7-a89e-d89c7754120d",
+            "position": 2,
+            "handlers": {},
+            "visible": true
+        },
+        "e1ax8ctt8lrao0e4": {
+            "id": "e1ax8ctt8lrao0e4",
+            "type": "tab",
+            "content": {
+                "name": "Pagination"
+            },
+            "parentId": "ee919cd6-8153-4f34-8c6a-bfc1153df360",
+            "position": 3,
+            "handlers": {},
+            "visible": true
+        },
+        "j3jkho6tb97u0onr": {
+            "id": "j3jkho6tb97u0onr",
+            "type": "repeater",
+            "content": {
+                "keyVariable": "itemId",
+                "valueVariable": "item",
+                "repeaterObject": "@{paginated_members}"
+            },
+            "parentId": "e1ax8ctt8lrao0e4",
+            "position": 0,
+            "handlers": {},
+            "visible": true
+        },
+        "4wzaubf275w17gac": {
+            "id": "4wzaubf275w17gac",
+            "type": "section",
+            "content": {
+                "title": "@{item.name} \u2b50\ufe0f"
+            },
+            "parentId": "j3jkho6tb97u0onr",
+            "position": 0,
+            "handlers": {},
+            "visible": true
+        },
+        "19binb4yi70gesho": {
+            "id": "19binb4yi70gesho",
+            "type": "text",
+            "content": {
+                "text": "**Role:** @{item.role}\n",
+                "useMarkdown": "yes"
+            },
+            "parentId": "4wzaubf275w17gac",
+            "position": 0
+        },
+        "zfp1koasiuleygmz": {
+            "id": "zfp1koasiuleygmz",
+            "type": "pagination",
+            "content": {
+                "page": "@{paginated_members_page}",
+                "pageSize": "@{paginated_members_page_size}",
+                "totalItems": "@{paginated_members_total_items}",
+                "pageSizeOptions": "1,2,5",
+                "pageSizeShowAll": "no",
+                "jumpTo": "no",
+                "urlParam": "no"
+            },
+            "parentId": "e1ax8ctt8lrao0e4",
+            "position": 1,
+            "handlers": {
+                "page-changed": "handle_paginated_members_page_change",
+                "page-size-changed": "handle_paginated_members_page_size_change"
             },
             "visible": true
         }

--- a/src/streamsync/app_templates/hello/main.py
+++ b/src/streamsync/app_templates/hello/main.py
@@ -64,7 +64,7 @@ def _generate_random_df():
 
 def _get_main_df():
     main_df = pd.read_csv("assets/main_df.csv")
-    return main_df.iloc[:10]
+    return main_df
 
 def _get_highlighted_members():
     sample_df = _get_main_df().sample(3).set_index("name", drop=False)

--- a/src/streamsync/app_templates/hello/ui.json
+++ b/src/streamsync/app_templates/hello/ui.json
@@ -351,7 +351,7 @@
                 "name": "Timer"
             },
             "parentId": "ee919cd6-8153-4f34-8c6a-bfc1153df360",
-            "position": 3
+            "position": 4
         },
         "db4c66d6-1eb7-44d3-a2d4-65d0b3e5cf12": {
             "id": "db4c66d6-1eb7-44d3-a2d4-65d0b3e5cf12",
@@ -909,6 +909,88 @@
             "position": 1,
             "handlers": {
                 "click": "handle_story_download"
+            },
+            "visible": true
+        },
+        "65y0txmxyzdiskun": {
+            "id": "65y0txmxyzdiskun",
+            "type": "pagination",
+            "content": {
+                "page": "4",
+                "pageSize": "25",
+                "totalItems": "100",
+                "pageSizeOptions": "",
+                "pageSizeShowAll": "no",
+                "jumpTo": "no",
+                "urlParam": "yopa"
+            },
+            "parentId": "9bb8a686-7013-4af7-a89e-d89c7754120d",
+            "position": 2,
+            "handlers": {},
+            "visible": true
+        },
+        "e1ax8ctt8lrao0e4": {
+            "id": "e1ax8ctt8lrao0e4",
+            "type": "tab",
+            "content": {
+                "name": "Pagination"
+            },
+            "parentId": "ee919cd6-8153-4f34-8c6a-bfc1153df360",
+            "position": 3,
+            "handlers": {},
+            "visible": true
+        },
+        "j3jkho6tb97u0onr": {
+            "id": "j3jkho6tb97u0onr",
+            "type": "repeater",
+            "content": {
+                "keyVariable": "itemId",
+                "valueVariable": "item",
+                "repeaterObject": "@{paginated_members}"
+            },
+            "parentId": "e1ax8ctt8lrao0e4",
+            "position": 0,
+            "handlers": {},
+            "visible": true
+        },
+        "4wzaubf275w17gac": {
+            "id": "4wzaubf275w17gac",
+            "type": "section",
+            "content": {
+                "title": "@{item.name} \u2b50\ufe0f"
+            },
+            "parentId": "j3jkho6tb97u0onr",
+            "position": 0,
+            "handlers": {},
+            "visible": true
+        },
+        "19binb4yi70gesho": {
+            "id": "19binb4yi70gesho",
+            "type": "text",
+            "content": {
+                "text": "**Role:** @{item.role}\n",
+                "useMarkdown": "yes"
+            },
+            "parentId": "4wzaubf275w17gac",
+            "position": 0
+        },
+        "zfp1koasiuleygmz": {
+            "id": "zfp1koasiuleygmz",
+            "type": "pagination",
+            "content": {
+                "page": "@{paginated_members_page}",
+                "pageSize": "@{paginated_members_page_size}",
+                "totalItems": "@{paginated_members_total_items}",
+                "pageSizeOptions": "2,5",
+                "pageSizeShowAll": "no",
+                "jumpTo": "no",
+                "urlParam": "no"
+            },
+            "parentId": "e1ax8ctt8lrao0e4",
+            "position": 1,
+            "handlers": {
+                "page-changed": "handle_paginated_members_page_change",
+                "page-size-changed": "handle_paginated_members_page_size_change"
             },
             "visible": true
         }

--- a/ui/src/core/templateMap.ts
+++ b/ui/src/core/templateMap.ts
@@ -40,6 +40,7 @@ import CoreVideoPlayer from "../core_components/CoreVideoPlayer.vue";
 
 import { StreamsyncComponentDefinition } from "../streamsyncTypes";
 import { h } from "vue";
+import CorePagination from "../core_components/CorePagination.vue";
 
 
 const templateMap = {
@@ -53,6 +54,7 @@ const templateMap = {
 	heading: CoreHeading,
 	dataframe: CoreDataframe,
 	html: CoreHtml,
+	pagination: CorePagination,
 	repeater: CoreRepeater,
 	column: CoreColumn,
 	columns: CoreColumns,

--- a/ui/src/core/templateMap.ts
+++ b/ui/src/core/templateMap.ts
@@ -10,6 +10,7 @@ import CoreHeader from "../core_components/CoreHeader.vue";
 import CoreHeading from "../core_components/CoreHeading.vue";
 import CoreDataframe from "../core_components/CoreDataframe.vue";
 import CoreHtml from "../core_components/CoreHtml.vue";
+import CorePagination from "../core_components/CorePagination.vue";
 import CoreRepeater from "../core_components/CoreRepeater.vue";
 import CoreColumn from "../core_components/CoreColumn.vue";
 import CoreColumns from "../core_components/CoreColumns.vue";
@@ -40,7 +41,7 @@ import CoreVideoPlayer from "../core_components/CoreVideoPlayer.vue";
 
 import { StreamsyncComponentDefinition } from "../streamsyncTypes";
 import { h } from "vue";
-import CorePagination from "../core_components/CorePagination.vue";
+
 
 
 const templateMap = {

--- a/ui/src/core_components/CorePagination.vue
+++ b/ui/src/core_components/CorePagination.vue
@@ -1,18 +1,63 @@
 <template>
-	<div></div>
+	<div class="pagination" ref="rootEl">
+		<div class="pagination-left">
+			<div class="pagination-pagesize" v-show="pagesizeEnabled">
+				<select class="pagesize-select" @change="onPageSizeChange">
+					<option v-for="o in pageSizeOptions" :value="o.value">{{ o.label }}</option>
+				</select>
+			</div>
+			<div class="pagination-description">
+				Showing <span class="bold">{{ firstItem }}</span> to <span class="bold">{{ lastItem }}</span> of <span class="bold">{{ totalItem }}</span> results
+			</div>
+		</div>
+		<div class="pagination-right">
+			<div class="pagination-picker">
+
+				<div class="paginationpicker-block ri-arrow-left-s-line"></div>
+				<template v-for="l in links">
+					<div v-if="l == '...'" class="paginationpicker-block paginationpicker-neutral">
+						{{ l }}
+					</div>
+					<div v-if="l != '...' && l != pageValue" class="paginationpicker-block" @click="jumpTo(l)">
+						{{ l }}
+					</div>
+					<div v-if="l == pageValue" class="paginationpicker-block paginationpicker-currentpage">
+						{{ l }}
+					</div>
+				</template>
+				<div class="paginationpicker-block ri-arrow-right-s-line"></div>
+			</div>
+			<div class="pagination-jump" v-show="jumptoEnabled">
+				<label>Jump to</label>
+				<input type="text" :value="pageValue" @input="onJumpTo"/>
+			</div>
+
+		</div>
+	</div>
 </template>
 
 <script lang="ts">
 import { FieldType } from "../streamsyncTypes";
 
 const pageChangeStub = `
-def handle_page_change(state):
+def handle_page_change(state, payload):
+    page = payload
+    state["page"] = page
 
-	# load only requested records from database
-	records = _load_records_from_db(start = state["page"] * state["pageSize"], limit = state["pageSize"])
+    records = _load_records_from_db(start = state["page"] * state["pageSize"], limit = state["pageSize"])
+    # update a repeater
+    state["highlighted_members"] = {r.id: r for r in records}
+`;
 
-	# update a repeater
-	state["highlighted_members"] = {r.id: r for r in records}`;
+
+const onPageSizeChangeStub = `
+def handle_page_size_change(state, payload):
+    state['pageSize'] = payload
+
+    records = _load_records_from_db(start = state["page"] * state["pageSize"], limit = state["pageSize"])
+    # update a repeater
+    state["highlighted_members"] = {r.id: r for r in records}
+`
 
 export default {
 	streamsync: {
@@ -30,13 +75,13 @@ export default {
 				name: "Page Size",
 				init: "25",
 				type: FieldType.Number,
-				desc: "The number of records per page.",
+				desc: "The number of items per page.",
 			},
 			totalItems: {
 				name: "Total Items",
 				init: "0",
 				type: FieldType.Number,
-				desc: "The total number of records",
+				desc: "The total number of items",
 			},
 			pageSizeOptions: {
 				name: "Page Size Options",
@@ -73,14 +118,205 @@ export default {
 		},
 		events: {
 			"page-changed": {
-				desc: "Fires when the user pick a page or change the page size.",
-				stub: pageChangeStub.trim()
+				desc: "Fires when the user pick a page",
+				stub: pageChangeStub.trim(),
+			},
+			"page-size-changed": {
+				desc: "Fires when the user change the page size.",
+				stub: onPageSizeChangeStub.trim()
 			}
 		}
 	}
 };
 </script>
 
-<style scoped>
+<script setup lang="ts">
+import {Ref, inject, ref, computed} from "vue";
+import injectionKeys from "../injectionKeys";
+import {useFormValueBroker} from "../renderer/useFormValueBroker";
 
+const fields = inject(injectionKeys.evaluatedFields);
+const ss = inject(injectionKeys.core);
+const rootEl = ref(null);
+const instancePath = inject(injectionKeys.instancePath);
+
+const {formValue: pageValue, handleInput: handlePageInput } = useFormValueBroker(ss, instancePath, rootEl);
+const {formValue: pageSizeValue, handleInput: handlePageSizeInput } = useFormValueBroker(ss, instancePath, rootEl);
+const pagesizeEnabled = computed(() => fields.pageSizeOptions.value !== "" || fields.pageSizeShowAll.value === "yes");
+const jumptoEnabled = computed(() => fields.jumpTo.value === "yes");
+
+const firstItem = computed(() => {
+	return (pageValue.value - 1) * (fields.pageSize.value) + 1
+});
+const lastItem = computed(() => Math.min((pageValue.value) * fields.pageSize.value, fields.totalItems.value));
+const totalItem = computed(() => fields.totalItems.value);
+const totalPage = computed(() => Math.ceil(parseInt(fields.totalItems.value) / parseInt(fields.pageSize.value)) - 1);
+
+const pageSizeOptions = computed(() => {
+	let options = []
+	const inputs = fields.pageSizeOptions.value.split(",")
+	for (const o in inputs) {
+		const n = parseInt(inputs[o], 10)
+		options.push({value: n, label:`${n} items`})
+
+	}
+	if (fields.pageSizeShowAll.value === "yes") {
+		options.push({value: -1, label: "All items"})
+	}
+
+	return options;
+});
+
+const links = computed(() => {
+	const links = [];
+	const page = parseInt(pageValue.value);
+
+	if (totalPage.value < 3) {
+		for (let i = 0; i <= totalPage.value; i++) {
+			links.push(i + 1);
+		}
+	} else if (page == 1 || page == 2) {
+		links.push(1);
+		links.push(2);
+		links.push(3);
+		links.push("...")
+		links.push(totalPage.value)
+	} else if (page == 3) {
+		links.push(1);
+		links.push(2);
+		links.push(3);
+		links.push(4);
+		links.push("...");
+		links.push(totalPage.value)
+	} else if (page == totalPage.value || page == totalPage.value - 1) {
+		links.push(1);
+		links.push("...");
+		links.push(totalPage.value - 2)
+		links.push(totalPage.value - 1)
+		links.push(totalPage.value)
+	} else if (page == totalPage.value - 2) {
+		links.push(1);
+		links.push("...");
+		links.push(totalPage.value - 3)
+		links.push(totalPage.value - 2)
+		links.push(totalPage.value - 1)
+		links.push(totalPage.value)
+	} else {
+		links.push(1)
+		links.push("...")
+		links.push(page - 1);
+		links.push(page);
+		links.push(page + 1);
+		links.push("...");
+		links.push(totalPage.value)
+	}
+
+	return links;
+})
+
+
+const onJumpTo = (event) => {
+	if (event.target.value === "") {
+		return;
+	}
+
+
+	let page = parseInt(event.target.value);
+	if (page > totalPage.value) {
+		page = totalPage.value;
+	}
+
+	handlePageInput(page, 'page-changed')
+};
+
+const jumpTo = (page: number) => {
+	handlePageInput(page, 'page-changed')
+}
+
+const onPageSizeChange = (event) => {
+	let pageSize = parseInt(event.target.value);
+	handlePageSizeInput(pageSize, 'page-size-changed')
+};
+
+</script>
+
+<style scoped>
+.pagination {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+
+	width: 100%;
+}
+
+.pagination-left {
+	display: flex;
+	justify-content: start;
+	align-items: center;
+	gap: 16px;
+	padding: 8px 0;
+}
+
+.pagination-right {
+	display: flex;
+	align-items: center;
+	justify-content: end;
+	gap: 16px;
+	flex-grow: 1;
+	padding: 8px 0;
+}
+
+.pagination-picker {
+	display: flex;
+	align-items: center;
+	gap: 0;
+}
+
+.pagination-jump {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.pagination-jump input {
+	width: 32px;
+	height: 30px;
+
+	border: 1px solid var(--separatorColor);
+	background-color: transparent;
+}
+
+.paginationpicker-block {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	height: 32px;
+	width: 32px;
+	border: 1px solid var(--separatorColor);
+	border-collapse: collapse;
+
+	margin-top: -1px;
+	margin-left: -1px;
+	cursor: pointer;
+}
+
+.paginationpicker-neutral {
+	cursor: default;
+}
+
+.pagesize-select {
+	height: 30px;
+	border: 1px solid var(--separatorColor);
+	background-color: transparent;
+}
+
+.bold {
+	font-weight: bold;
+}
+
+.paginationpicker-currentpage {
+	background-color: var(--accentColor);
+	color: var(--emptinessColor);
+}
 </style>

--- a/ui/src/core_components/CorePagination.vue
+++ b/ui/src/core_components/CorePagination.vue
@@ -177,7 +177,7 @@ const links = computed(() => {
 	const links = [];
 	const page = parseInt(fields.page.value);
 
-	if (totalPage.value <= 3) {
+	if (totalPage.value <= 7) {
 		for (let i = 0; i < totalPage.value; i++) {
 			links.push(i + 1);
 		}
@@ -186,22 +186,37 @@ const links = computed(() => {
 		links.push(2);
 		links.push(3);
 		links.push("...")
+		links.push(totalPage.value - 2)
+		links.push(totalPage.value - 1)
 		links.push(totalPage.value)
 	} else if (page == 3) {
 		links.push(1);
 		links.push(2);
 		links.push(3);
 		links.push(4);
-		links.push("...");
+		links.push("...")
+		// links.push(totalPage.value - 2)
+		links.push(totalPage.value - 1)
+		links.push(totalPage.value)
+	} else if (page == 4) {
+		links.push(1);
+		links.push(2);
+		links.push(3);
+		links.push(4);
+		links.push(5)
+		links.push("...")
 		links.push(totalPage.value)
 	} else if (page == totalPage.value || page == totalPage.value - 1) {
 		links.push(1);
+		links.push(2);
+		links.push(3);
 		links.push("...");
 		links.push(totalPage.value - 2)
 		links.push(totalPage.value - 1)
 		links.push(totalPage.value)
-	} else if (page == totalPage.value - 2) {
+	}else if (page == totalPage.value - 2) {
 		links.push(1);
+		links.push(2);
 		links.push("...");
 		links.push(totalPage.value - 3)
 		links.push(totalPage.value - 2)

--- a/ui/src/core_components/CorePagination.vue
+++ b/ui/src/core_components/CorePagination.vue
@@ -1,0 +1,20 @@
+<template>
+	<div></div>
+</template>
+
+<script lang="ts">
+import { FieldCategory, FieldType } from "../streamsyncTypes";
+
+export default {
+	streamsync: {
+		name: "Pagination",
+		category: "Other",
+		fields: {},
+		events: {}
+	}
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/ui/src/core_components/CorePagination.vue
+++ b/ui/src/core_components/CorePagination.vue
@@ -3,7 +3,16 @@
 </template>
 
 <script lang="ts">
-import { FieldCategory, FieldType } from "../streamsyncTypes";
+import { FieldType } from "../streamsyncTypes";
+
+const pageChangeStub = `
+def handle_page_change(state):
+
+	# load only requested records from database
+	records = _load_records_from_db(start = state["page"] * state["pageSize"], limit = state["pageSize"])
+
+	# update a repeater
+	state["highlighted_members"] = {r.id: r for r in records}`;
 
 export default {
 	streamsync: {
@@ -31,9 +40,9 @@ export default {
 			},
 			pageSizeOptions: {
 				name: "Page Size Options",
-				init: "25,50,100",
+				init: "",
 				type: FieldType.Text,
-				desc: "A comma-separated list of page size options.",
+				desc: "A comma-separated list of page size options. If it's empty, the user can't change the page size.",
 			},
 			pageSizeShowAll: {
 				name: "Show All Option",
@@ -62,7 +71,12 @@ export default {
 				desc: "The URL parameter to use for the page number. If it's empty, the page is not saved on the url.",
 			},
 		},
-		events: {}
+		events: {
+			"page-changed": {
+				desc: "Fires when the user pick a page or change the page size.",
+				stub: pageChangeStub.trim()
+			}
+		}
 	}
 };
 </script>

--- a/ui/src/core_components/CorePagination.vue
+++ b/ui/src/core_components/CorePagination.vue
@@ -67,30 +67,32 @@ export default {
 			page: {
 				name: "Page",
 				init: "1",
+				default: "1",
 				type: FieldType.Number,
 				desc: "The current page number.",
 			},
 			pageSize: {
 				name: "Page Size",
-				init: "25",
+				default: "10",
 				type: FieldType.Number,
 				desc: "The number of items per page.",
 			},
 			totalItems: {
 				name: "Total Items",
-				init: "0",
+				default: "10",
 				type: FieldType.Number,
 				desc: "The total number of items",
 			},
 			pageSizeOptions: {
 				name: "Page Size Options",
 				init: "",
+				default: "",
 				type: FieldType.Text,
 				desc: "A comma-separated list of page size options. If it's empty, the user can't change the page size. Set your default page size as the first option."
 			},
 			pageSizeShowAll: {
 				name: "Show All Option",
-				init: "no",
+				default: "no",
 				type: FieldType.Text,
 				options: {
 					yes: "Yes",
@@ -100,7 +102,7 @@ export default {
 			},
 			jumpTo: {
 				name: "Jump To",
-				init: "no",
+				default: "no",
 				type: FieldType.Text,
 				options: {
 					yes: "Yes",
@@ -108,16 +110,18 @@ export default {
 				},
 				desc: "Show an option to jump to a specific page.",
 			},
-			urlParam: {
-				name: "Url parameters",
-				init: "no",
-				type: FieldType.Text,
-				options: {
-					yes: "Yes",
-					no: "No",
-				},
-				desc: "Set the page size and the page as URL parameters. Default, will be page and pageSize."
-			}
+			// Disabled for now, I am waiting functions to manipulate Hash params from the URL
+			//
+			// urlParam: {
+			// 	name: "Url parameters",
+			// 	default: "no",
+			// 	type: FieldType.Text,
+			// 	options: {
+			// 		yes: "Yes",
+			// 		no: "No",
+			// 	},
+			// 	desc: "Set the page size and the page as URL parameters. Default, will be page and pageSize."
+			// }
 		},
 		events: {
 			"page-changed": {
@@ -279,55 +283,65 @@ const onPageSizeChange = (event) => {
 
 
 watch(fields.page, () => {
-	if (fields.urlParam.value.trim() === "yes") {
-		const searchURL = new URL(window.location);
-		searchURL.searchParams.set("page", fields.page.value)
-		window.history.replaceState({}, '', searchURL);
-	}
+	// Disabled for now, I am waiting functions to manipulate Hash params from the URL
+
+	// if (fields.urlParam.value.trim() === "yes") {
+	// 	const searchURL = new URL(window.location);
+	// 	searchURL.searchParams.set("page", fields.page.value)
+	// 	window.history.replaceState({}, '', searchURL);
+	// }
 });
 
 watch(fields.pageSize, () => {
-	if (fields.urlParam.value.trim() === "yes") {
-		const searchURL = new URL(window.location);
-		searchURL.searchParams.set("pageSize", fields.pageSize.value)
-		window.history.replaceState({}, '', searchURL);
-	}
+	// Disabled for now, I am waiting functions to manipulate Hash params from the URL
+
+	// if (fields.urlParam.value.trim() === "yes") {
+	// 	const searchURL = new URL(window.location);
+	// 	searchURL.searchParams.set("pageSize", fields.pageSize.value)
+	// 	window.history.replaceState({}, '', searchURL);
+	// }
 });
 
 onMounted(() => {
 	/**
 	 * On page load, get URL parameters and configure pagination.
 	 */
-	const searchURL = new URL(window.location);
 
-	if (searchURL.searchParams.has("pageSize")) {
-		const pageSize = searchURL.searchParams.get("pageSize");
-		handlePageSizeInput(parseInt(pageSize), 'page-size-changed', () => {
-			if (searchURL.searchParams.has("page")) {
-				const page = searchURL.searchParams.get("page");
-				jumpTo(parseInt(page));
-			}
-		})
-	} else {
-		if (searchURL.searchParams.has("page")) {
-			const page = searchURL.searchParams.get("page");
-			jumpTo(parseInt(page));
-		}
-	}
+	// Disabled for now, I am waiting functions to manipulate Hash params from the URL
+
+	// const searchURL = new URL(window.location);
+	//
+	// if (searchURL.searchParams.has("pageSize")) {
+	// 	const pageSize = searchURL.searchParams.get("pageSize");
+	// 	handlePageSizeInput(parseInt(pageSize), 'page-size-changed', () => {
+	// 		if (searchURL.searchParams.has("page")) {
+	// 			const page = searchURL.searchParams.get("page");
+	// 			jumpTo(parseInt(page));
+	// 		}
+	// 	})
+	// } else {
+	// 	if (searchURL.searchParams.has("page")) {
+	// 		const page = searchURL.searchParams.get("page");
+	// 		jumpTo(parseInt(page));
+	// 	}
+	// }
 })
 
 onUnmounted(() => {
 	/**
 	 * When changing pages, eliminates URL parameters that are not useful on the next page.
 	 */
-	const searchURL = new URL(window.location);
-	if (searchURL.searchParams.has("page")) {
-		searchURL.searchParams.delete("page");
-	}
-	if (searchURL.searchParams.has("pageSize")) {
-		searchURL.searchParams.delete("pageSize");
-	}
-	window.history.replaceState({}, '', searchURL);
+
+	// Disabled for now, I am waiting functions to manipulate Hash params from the URL
+
+	// const searchURL = new URL(window.location);
+	// if (searchURL.searchParams.has("page")) {
+	// 	searchURL.searchParams.delete("page");
+	// }
+	// if (searchURL.searchParams.has("pageSize")) {
+	// 	searchURL.searchParams.delete("pageSize");
+	// }
+	// window.history.replaceState({}, '', searchURL);
 })
 
 </script>

--- a/ui/src/core_components/CorePagination.vue
+++ b/ui/src/core_components/CorePagination.vue
@@ -9,7 +9,59 @@ export default {
 	streamsync: {
 		name: "Pagination",
 		category: "Other",
-		fields: {},
+		description: "paginates records from a repeater or dataframe",
+		fields: {
+			page: {
+				name: "Page",
+				init: "1",
+				type: FieldType.Number,
+				desc: "The current page number.",
+			},
+			pageSize: {
+				name: "Page Size",
+				init: "25",
+				type: FieldType.Number,
+				desc: "The number of records per page.",
+			},
+			totalItems: {
+				name: "Total Items",
+				init: "0",
+				type: FieldType.Number,
+				desc: "The total number of records",
+			},
+			pageSizeOptions: {
+				name: "Page Size Options",
+				init: "25,50,100",
+				type: FieldType.Text,
+				desc: "A comma-separated list of page size options.",
+			},
+			pageSizeShowAll: {
+				name: "Show All Option",
+				init: "no",
+				type: FieldType.Text,
+				options: {
+					yes: "Yes",
+					no: "No",
+				},
+				desc: "Show an option to show all records.",
+			},
+			jumpTo: {
+				name: "Jump To",
+				init: "no",
+				type: FieldType.Text,
+				options: {
+					yes: "Yes",
+					no: "No",
+				},
+				desc: "Show an option to jump to a specific page.",
+			},
+			urlParam: {
+				name: "URL Param",
+				init: "",
+				type: FieldType.Text,
+				desc: "The URL parameter to use for the page number. If it's empty, the page is not saved on the url.",
+			},
+		},
 		events: {}
 	}
 };

--- a/ui/src/core_components/CorePagination.vue
+++ b/ui/src/core_components/CorePagination.vue
@@ -12,8 +12,7 @@
 		</div>
 		<div class="pagination-right">
 			<div class="pagination-picker">
-
-				<div class="paginationpicker-block ri-arrow-left-s-line"></div>
+				<div class="paginationpicker-block ri-arrow-left-s-line" :class="{'paginationpicker-disabled': pagePreviousDisabled}" @click="jumpTo(fields.page.value - 1)"></div>
 				<template v-for="l in links">
 					<div v-if="l == '...'" class="paginationpicker-block paginationpicker-neutral">
 						{{ l }}
@@ -25,7 +24,7 @@
 						{{ l }}
 					</div>
 				</template>
-				<div class="paginationpicker-block ri-arrow-right-s-line"></div>
+				<div class="paginationpicker-block ri-arrow-right-s-line" :class="{'paginationpicker-disabled': pageNextDisabled}" @click="jumpTo(fields.page.value + 1)"></div>
 			</div>
 			<div class="pagination-jump" v-show="jumptoEnabled">
 				<label>Jump to</label>
@@ -156,6 +155,7 @@ const lastItem = computed(() => Math.min((fields.page.value) * fields.pageSize.v
 const totalItem = computed(() => fields.totalItems.value);
 const totalPage = computed(() => Math.ceil(parseInt(fields.totalItems.value) / parseInt(fields.pageSize.value)));
 
+
 const pageSizeOptions = computed(() => {
 	let options = []
 	const inputs = fields.pageSizeOptions.value.split(",")
@@ -170,6 +170,9 @@ const pageSizeOptions = computed(() => {
 	return options;
 });
 
+/**
+ * Calculate the links to show in the pagination
+ */
 const links = computed(() => {
 	const links = [];
 	const page = parseInt(fields.page.value);
@@ -217,6 +220,22 @@ const links = computed(() => {
 	return links;
 })
 
+/**
+ * Disable the previous page button if the current page is the first page.
+ */
+const pagePreviousDisabled = computed(() => {
+	const previousPage = parseInt(fields.page.value) - 1;
+	return previousPage < 1;
+});
+
+/**
+ * Disable the next page button if the current page is the last page.
+ */
+const pageNextDisabled = computed(() => {
+	const nextPage = parseInt(fields.page.value) + 1;
+	return nextPage > totalPage.value;
+});
+
 
 const onJumpTo = (event) => {
 	if (event.target.value === "") {
@@ -235,6 +254,8 @@ const onJumpTo = (event) => {
 const jumpTo = (page: number) => {
 	handlePageInput(page, 'page-changed')
 }
+
+
 
 const onPageSizeChange = (event) => {
 	let pageSize = parseInt(event.target.value);
@@ -357,6 +378,16 @@ onUnmounted(() => {
 	cursor: pointer;
 }
 
+.paginationpicker-currentpage {
+	background-color: var(--accentColor);
+	color: var(--emptinessColor);
+}
+
+.paginationpicker-disabled {
+	cursor: default;
+	pointer-events: none;
+}
+
 .paginationpicker-neutral {
 	cursor: default;
 }
@@ -369,10 +400,5 @@ onUnmounted(() => {
 
 .bold {
 	font-weight: bold;
-}
-
-.paginationpicker-currentpage {
-	background-color: var(--accentColor);
-	color: var(--emptinessColor);
 }
 </style>


### PR DESCRIPTION
This PR implements a Pagination component. This component allows to split a dataframe or repeater into several pages if it's too large. Pagination is a robust solution for displaying dataframes of several thousands rows.

![Peek 2023-11-18 21-45](https://github.com/streamsync-cloud/streamsync/assets/159559/a889dfc1-20ef-4a64-92bb-6152a193b268)

I've documented its usage on ``hello`` app.

### User.

* user can change page
* user goes to previous page / to next page
* user can change the number of elements per page (optional)
* the user can go to a specific page (optional)

### Developer

* the developer associates the number of records with a server state
* the developer associates the number of records per page with a server state (optional)
* the developer can enable fast movement to a specific page
* the developer can suggest to the user to change the number of pages
* the developer subscribes a page change to a backend event
* the developer subscribes a page size change to a backend event

demo as custom extension : [custom_pagination.zip](https://github.com/streamsync-cloud/streamsync/files/13419349/custom_pagination.zip)