### PR TITLE
Off-by-one issue in the DataFrame - Last line is not shown in dataframe component on firefox

### DIFF
--- a/ui/src/core_components/CoreDataframe.vue
+++ b/ui/src/core_components/CoreDataframe.vue
@@ -272,7 +272,7 @@ const rowOffset = computed(() => {
 		maxOffset = rowCount.value - displayRowCount.value;
 	}
 	const newOffset = Math.min(
-		Math.floor(relativePosition.value * maxOffset),
+		Math.ceil(relativePosition.value * maxOffset),
 		maxOffset,
 	);
 	return newOffset;


### PR DESCRIPTION
The fix has been designed by @thondeboer. It's describe in [https://github.com/streamsync-cloud/streamsync/issues/188](https://github.com/streamsync-cloud/streamsync/issues/188)

---
I have triggered the bug on `ubuntu / firefox 120.0.1 (64-bit)`. The test case was working fine on `ubuntu / chromium 112.0.5615.49` with streamsync 0.2.8