### PR TITLE
Support huge plotly plots on streamsync

### DIFF
--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -120,6 +120,8 @@ class StateSerialiser:
 
         if "matplotlib.figure.Figure" in v_mro:
             return self._serialise_matplotlib_fig(v)
+        if "plotly.graph_objs._figure.Figure" in v_mro:
+            return v.to_json()
         if "numpy.float64" in v_mro:
             return float(v)
         if "numpy.ndarray" in v_mro:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,6 +8,7 @@ from streamsync.core import (BytesWrapper, ComponentManager, Evaluator, EventDes
 import streamsync as ss
 from streamsync.ss_types import StreamsyncEvent
 import pandas as pd
+import plotly.express as px
 import pytest
 import altair
 import pyarrow as pa
@@ -486,6 +487,26 @@ class TestStateSerialiser():
         with pytest.warns(UserWarning):
             with pytest.raises(ValueError):
                 self.sts.serialise(d)
+                
+    def test_plotly_should_be_serialize_to_json(self) -> None:
+        """
+        Test that plotly figure should be serialised to json string directly. Serializing the json directly allows you 
+        to display datasets that exceed 10,000 records. 
+        
+        With the default json serializer, a dataset like this blows up memory. Plotly is using internaly orjson as serializer.
+        """
+        # Arrange
+        df = px.data.iris()
+        fig = px.scatter(df, x="sepal_width", y="sepal_length", color="species", symbol="species")
+        
+        # Acts
+        json_code = self.sts.serialise(fig)
+
+        # Assert
+        assert isinstance(json_code, str)
+        o = json.loads(json_code)
+        assert 'data' in o
+        assert 'layout' in o
 
     def test_pandas_df(self) -> None:
         d = {


### PR DESCRIPTION
solve the issue [Large plotly plots will crash streamsync, while dash has no issues showing the same...](https://github.com/streamsync-cloud/streamsync/issues/190)

---

Python's default serializer is very greedy on a plotly object. It is difficult to render a visualization of more than 5000 elements.

Plotly implements its own serializer using orjson. This is what should be used in streamsync.