### PR TITLE
Data race in StateProxy.state

### DIFF
--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -231,7 +231,7 @@ class StateProxy:
     def get_mutations_as_dict(self) -> Dict[str, Any]:
         serialised_mutations: Dict[str, Union[Dict,
                                               List, str, bool, int, float, None]] = {}
-        for key, value in self.state.items():
+        for key, value in list(self.state.items()):
             if key.startswith("_"):
                 continue
             escaped_key = key.replace(".", "\.")


### PR DESCRIPTION
when state is changed concurrently. Suggested mitigation: construct a list of the items first, and then iterate. A safer solution would be to make a lock around constructing the list, but that's more work due to the recursive construction in StateProxy. list(...) is not atomic in Python and the iterator could change while constructing the list. In practice, this change fixed the problem for me.

```
Traceback (most recent call last):
  File "/app/venv/lib/python3.11/site-packages/streamsync/app_runner.py", line 191, in _handle_state_enquiry
      mutations = session.session_state.user_state.get_mutations_as_dict()

  File "/app/venv/lib/python3.11/site-packages/streamsync/core.py", line 232, in get_mutations_as_dict for key, value in self.state.items():
    RuntimeError: dictionary changed size during iteration
```