### PR TITLE
Fix: Use escaped keys in StateProxy serialization

### DIFF
--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -239,7 +239,7 @@ class StateProxy:
             serialised_value = None
             if isinstance(value, StateProxy):
                 if value.initial_assignment:
-                    serialised_mutations[key] = serialised_value
+                    serialised_mutations[escaped_key] = serialised_value
                 value.initial_assignment = False
                 child_mutations = value.get_mutations_as_dict()
                 if child_mutations is None:


### PR DESCRIPTION
Corrected the use of escaped keys in serializing StateProxy mutations. Replaced instance where unescaped key was used, ensuring consistency and correct handling of keys with dots.