### PR TITLE
Expanding mutation test

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -92,6 +92,10 @@ class TestStateProxy:
         assert m.get("state\\.with\\.dots.photo\\.jpeg") == "Corrupted"
         assert len(m) == 1
 
+        self.sp["new.state.with.dots"] = {"test": "test"}
+        m = self.sp.get_mutations_as_dict()
+        assert len(m) == 1
+
         d = self.sp.to_dict()
         assert d.get("age") == 2
         assert d.get("interests") == ["lamps", "cars", "dogs"]


### PR DESCRIPTION
`Adding a class method to count initial mutations for a StateProxy. Checking the amount of mutations per each step of the test to ensure that mutations are properly tracked.`

In regards to our prior discussion with @ramedina86, I found that the most reliable way to avoid issues like #198 in the future is to consistently track how many mutations are produced by the `get_mutations_as_dict` method in `StateProxy`, and compare the amount to the "ground truth" (i.e. actual number of mutations, which is easily deductible). I updated the mutation test to do exactly that. A method that counts expected "initial mutations" was also added, to make the test independent from the state of the dictionary initially passed to `TestStateProxy`.

I will be considering designing other tests as well, and any feedback is appreciated on the way.