### PR TITLE
Enabling deletion mutations

### DIFF
--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -266,7 +266,7 @@ class StateProxy:
                 for child_key, child_mutation in child_mutations.items():
                     nested_key = carry_mutation_flag(escaped_key, child_key)
                     serialised_mutations[nested_key] = child_mutation
-            else:
+            elif f"+{key}" in self.mutated:
                 try:
                     serialised_value = state_serialiser.serialise(value)
                 except BaseException:

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -258,7 +258,7 @@ class StateProxy:
             serialised_mutations[f"{key}"] = None
 
         for key, value in list(self.state.items()):
-            if key.startswith("_") or key.startswith("-"):
+            if key.startswith("_"):
                 continue
             escaped_key = self.escape_key(key)
 

--- a/tests/test_app_runner.py
+++ b/tests/test_app_runner.py
@@ -98,9 +98,9 @@ class TestAppRunner:
         assert ev_res.status == "ok"
         assert ev_res.payload.result.get("ok") == True
         assert ev_res.payload.mutations.get(
-            "inspected_payload") == "129673.0"
+            "+inspected_payload") == "129673.0"
         assert ev_res.payload.mutations.get(
-            "b.pet_count") == 129673
+            "+b.pet_count") == 129673
         ar.shut_down()
 
     @pytest.mark.asyncio

--- a/ui/src/core/index.ts
+++ b/ui/src/core/index.ts
@@ -131,8 +131,9 @@ export function generateCore() {
 			
 			// Check if the accessor is meant for deletion.
 			const isDeletion = accessor[lastElementIndex].charAt(0) === '-';
+			const isAddition = accessor[lastElementIndex].charAt(0) === '+';
 			
-			if (isDeletion) {
+			if (isDeletion || isAddition) {
 				// Remove the prefix for processing.
 				accessor[lastElementIndex] = accessor[lastElementIndex].substring(1);
 			}

--- a/ui/src/core/index.ts
+++ b/ui/src/core/index.ts
@@ -124,19 +124,14 @@ export function generateCore() {
 			Splits the key while respecting escaped dots.
 			For example, "files.myfile\.sh" will be split into ["files", "myfile.sh"] 
 			*/
-
-			const accessor = parseAccessor(key);
+			
+			const mutationFlag = key.charAt(0)
+			const accessor = parseAccessor(key.substring(1));
 			let lastElementIndex = accessor.length - 1
 			let stateRef = userState.value;
 			
 			// Check if the accessor is meant for deletion.
-			const isDeletion = accessor[lastElementIndex].charAt(0) === '-';
-			const isAddition = accessor[lastElementIndex].charAt(0) === '+';
-			
-			if (isDeletion || isAddition) {
-				// Remove the prefix for processing.
-				accessor[lastElementIndex] = accessor[lastElementIndex].substring(1);
-			}
+			const isDeletion = mutationFlag === '-';
 			
 			for (let i = 0; i < lastElementIndex; i++) {
 				let nextStateRef = stateRef?.[accessor[i]];


### PR DESCRIPTION
Providing `__delitem__` method for `StateProxy` and `StreamsyncState`, and dict-like `remove()` API referencing the same method. Adding a "-" prefix for state keys meant to be removed at the frontend side when applying for mutated set of `StateProxy`. Enabling frontend to distinguish deletion mutations in `ingestMutations` function of `core/index.ts`.