### PR TITLE
chore: linking ComponentManager to session

### DIFF
--- a/src/streamsync/__init__.py
+++ b/src/streamsync/__init__.py
@@ -1,11 +1,10 @@
 import importlib.metadata
 from typing import Union, Optional, Dict, Any
 from streamsync.core import Readable, FileWrapper, BytesWrapper, Config
-from streamsync.core import initial_state, component_manager, session_manager, session_verifier
+from streamsync.core import initial_state, session_manager, session_verifier
 
 VERSION = importlib.metadata.version("streamsync")
 
-component_manager
 session_manager
 Config
 session_verifier

--- a/src/streamsync/__init__.py
+++ b/src/streamsync/__init__.py
@@ -1,10 +1,11 @@
 import importlib.metadata
 from typing import Union, Optional, Dict, Any
 from streamsync.core import Readable, FileWrapper, BytesWrapper, Config
-from streamsync.core import initial_state, session_manager, session_verifier
+from streamsync.core import initial_state, base_component_tree, session_manager, session_verifier
 
 VERSION = importlib.metadata.version("streamsync")
 
+base_component_tree
 session_manager
 Config
 session_verifier

--- a/src/streamsync/app_runner.py
+++ b/src/streamsync/app_runner.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, List, Optional, cast
 from watchdog.observers.polling import PollingObserver
 
 from pydantic import ValidationError
-from streamsync.core import ComponentTree, StreamsyncSession
+from streamsync.core import StreamsyncSession
 from streamsync.ss_types import (AppProcessServerRequest, AppProcessServerRequestPacket, AppProcessServerResponse, AppProcessServerResponsePacket, ComponentUpdateRequest, ComponentUpdateRequestPayload,
                                  EventRequest, EventResponsePayload, InitSessionRequest, InitSessionRequestPayload, InitSessionResponse, InitSessionResponsePayload, StateEnquiryRequest, StateEnquiryResponsePayload, StreamsyncEvent)
 import watchdog.observers
@@ -261,7 +261,7 @@ class AppProcess(multiprocessing.Process):
         if self.mode == "edit" and type == "componentUpdate":
             cu_req_payload = ComponentUpdateRequestPayload.parse_obj(
                 request.payload)
-            session.component_manager.ingest(cu_req_payload.components)
+            self._handle_component_update(cu_req_payload)
             return AppProcessServerResponse(
                 status="ok",
                 status_message=None,

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -885,7 +885,7 @@ class StreamsyncSession:
         self.component_manager = ComponentManager()
         if components:
             try:
-                self.component_manager.ingest(self.components)
+                self.component_manager.ingest(components)
             except BaseException:
                 self.session_state.add_log_entry(
                     "error", "UI Components Error", "Couldn't load components. An exception was raised.", tb.format_exc())

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -769,13 +769,16 @@ class Evaluator:
 
         component_id = instance_path[-1]["componentId"]
         component = self.ct.get_component(component_id)
-        field_value = component.content.get(field_key) or default_field_value
-        replaced = self.template_regex.sub(replacer, field_value)
+        if component:
+            field_value = component.content.get(field_key) or default_field_value
+            replaced = self.template_regex.sub(replacer, field_value)
 
-        if as_json:
-            return json.loads(replaced)
+            if as_json:
+                return json.loads(replaced)
+            else:
+                return replaced
         else:
-            return replaced
+            raise ValueError(f"Couldn't acquire a component by ID '{component_id}'")
 
     def get_context_data(self, instance_path: InstancePath) -> Dict[str, Any]:
         context: Dict[str, Any] = {}
@@ -783,6 +786,8 @@ class Evaluator:
             path_item = instance_path[i]
             component_id = path_item["componentId"]
             component = self.ct.get_component(component_id)
+            if not component:
+                continue
             if component.type != "repeater":
                 continue
             if i + 1 >= len(instance_path):

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -16,7 +16,6 @@ import io
 import re
 import json
 import math
-import traceback as tb
 from streamsync.ss_types import Readable, InstancePath, StreamsyncEvent, StreamsyncEventResult, StreamsyncFileItem
 
 
@@ -513,7 +512,7 @@ class ComponentTree:
         root_component = Component("root", "root", {})
         self.attach(root_component)
 
-    def get_component(self, component_id: str) -> Component:
+    def get_component(self, component_id: str) -> Optional[Component]:
         return self.components.get(component_id)
 
     def get_descendents(self, parent_id: str) -> List[Component]:
@@ -559,7 +558,7 @@ class SessionComponentTree(ComponentTree):
         super().__init__()
         self.base_component_tree = base_component_tree
 
-    def get_component(self, component_id: str) -> Component:
+    def get_component(self, component_id: str) -> Optional[Component]:
         base_component = self.base_component_tree.get_component(component_id)
         if base_component:
             return base_component

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -48,7 +48,8 @@ with open(test_app_dir / "ui.json", "r") as f:
 
 ss.Config.is_mail_enabled_for_log = True
 ss.init_state(raw_state_dict)
-ss.component_manager.ingest(sc)
+session = ss.session_manager.get_new_session()
+session.component_manager.ingest(sc)
 
 
 class TestStateProxy:
@@ -237,7 +238,7 @@ class TestEventDeserialiser:
 
     root_instance_path = [{"componentId": "root", "instanceNumber": 0}]
     session_state = StreamsyncState(raw_state_dict)
-    ed = EventDeserialiser(session_state)
+    ed = EventDeserialiser(session.session_id, session_state)
 
     def test_unknown_no_payload(self) -> None:
         ev = StreamsyncEvent(
@@ -598,7 +599,7 @@ class TestEvaluator:
         st = StreamsyncState({
             "counter": 8
         })
-        e = Evaluator(st)
+        e = Evaluator(session.session_id, st)
         evaluated = e.evaluate_field(instance_path, "text")
         assert evaluated == "The counter is 8"
 
@@ -622,7 +623,7 @@ class TestEvaluator:
                 "ts": "TypeScript"
             }
         })
-        e = Evaluator(st)
+        e = Evaluator(session.session_id, st)
         assert e.evaluate_field(
             instance_path_0, "text") == "The id is c and the name is C"
         assert e.evaluate_field(
@@ -633,7 +634,7 @@ class TestEvaluator:
             {"componentId": "root", "instanceNumber": 0}
         ]
         st = StreamsyncState(raw_state_dict)
-        e = Evaluator(st)
+        e = Evaluator(session.session_id, st)
         e.set_state("name", instance_path, "Roger")
         e.set_state("dynamic_prop", instance_path, "height")
         e.set_state("features[dynamic_prop]", instance_path, "toddler height")
@@ -647,7 +648,7 @@ class TestEvaluator:
             {"componentId": "root", "instanceNumber": 0}
         ]
         st = StreamsyncState(raw_state_dict)
-        e = Evaluator(st)
+        e = Evaluator(session.session_id, st)
         assert e.evaluate_expression("features.eyes", instance_path) == "green"
         assert e.evaluate_expression("best_feature", instance_path) == "eyes"
         assert e.evaluate_expression("features[best_feature]", instance_path) == "green"


### PR DESCRIPTION
Making ComponentManager a part of session as a prerequisite to link the state of the UI to each particular session instead of the whole app.