### PR TITLE
feat: allow running review app to validate pr from external contribution

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/FabienArcellier/nodejs-buildpack#streamsync-review
+https://github.com/FabienArcellier/python-buildpack#streamsync-review

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: streamsync --port $PORT --host 0.0.0.0 --enable-remote-edit edit apps/hello

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: streamsync --port $PORT --host 0.0.0.0 --enable-remote-edit edit apps/hello
+web: python apps/reviewapp.py

--- a/apps/reviewapp.py
+++ b/apps/reviewapp.py
@@ -1,0 +1,43 @@
+import os
+
+import uvicorn
+from fastapi.responses import HTMLResponse
+from fastapi import FastAPI, Response
+
+import streamsync.serve
+
+
+def app_path(app_name: str) -> str:
+    return os.path.join(os.path.dirname(__file__), app_name)
+
+root_asgi_app = FastAPI(lifespan=streamsync.serve.lifespan)
+sub_asgi_app_1 = streamsync.serve.get_asgi_app(app_path("hello"), "edit", enable_remote_edit=True)
+sub_asgi_app_2 = streamsync.serve.get_asgi_app(app_path("default"), "edit", enable_remote_edit=True)
+sub_asgi_app_3 = streamsync.serve.get_asgi_app(app_path("quickstart"), "edit", enable_remote_edit=True)
+
+root_asgi_app.mount("/hello/", sub_asgi_app_1)
+root_asgi_app.mount("/default/", sub_asgi_app_2)
+root_asgi_app.mount("/quickstart/", sub_asgi_app_3)
+
+
+
+@root_asgi_app.get("/")
+async def init():
+    links = [
+        f'<li><a href="/hello">hello</a></li>',
+        f'<li><a href="/default"">default</a></li>',
+        f'<li><a href="/quickstart">quickstart</a></li>',
+    ]
+
+    return HTMLResponse("""
+        <h1>Streamsync review app</h1>
+        <ul>
+        """ + "\n".join(links) + """
+        </ul>
+        """, status_code=200)
+
+uvicorn.run(root_asgi_app,
+    host="0.0.0.0",
+    port=os.getenv('PORT', 8000),
+    log_level="warning",
+    ws_max_size=streamsync.serve.MAX_WEBSOCKET_MESSAGE_SIZE)

--- a/apps/reviewapp.py
+++ b/apps/reviewapp.py
@@ -1,10 +1,25 @@
+"""
+This is a simple application to help our team to review contribution.
+
+>>> python apps/reviewapp.py
+
+Runs this application in public and requires authentication.
+
+>>> export HOST=0.0.0.0; export BASICAUTH=admin:admin; python apps/reviewapp.py
+"""
+import base64
 import os
+import time
 
 import uvicorn
 from fastapi.responses import HTMLResponse
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, status
 
 import streamsync.serve
+
+HOST = os.getenv('HOST', 'localhost')
+PORT = int(os.getenv('PORT', '8000'))
+print(f"listen on {HOST}:{PORT}")
 
 
 def app_path(app_name: str) -> str:
@@ -36,8 +51,65 @@ async def init():
         </ul>
         """, status_code=200)
 
+
+
+@root_asgi_app.middleware("http")
+async def valid_authentication(request, call_next):
+    """
+    Secures access to the review application using basic auth
+
+    The username and password is stored in the BASICAUTH environment variable.
+    The authentication process is sequential and when it's wrong it take one second to try again. This protection
+    is sufficient to limit brute force attack.
+    """
+    if HOST == 'localhost':
+        """
+        Locally, you can launch the review application without needing to authenticate.
+        
+        The application bypass the authentication middleware.
+        """
+        return await call_next(request)
+
+    _auth = request.headers.get('Authorization')
+    if not check_permission(_auth):
+        return HTMLResponse("", status.HTTP_401_UNAUTHORIZED, {"WWW-Authenticate": "Basic"})
+    return await call_next(request)
+
+
+def check_permission(auth) -> bool:
+    """
+    Secures access to the review application using basic auth
+
+    >>> is_valid_token = check_permission('Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
+    """
+    if auth is None:
+        return False
+
+    scheme, data = (auth or ' ').split(' ', 1)
+    if scheme != 'Basic':
+        return False
+
+    username, password = base64.b64decode(data).decode().split(':', 1)
+    basicauth = os.getenv('BASICAUTH')
+    if auth is None:
+        raise ValueError('BASICAUTH environment variable is not set')
+
+    basicauth_part = basicauth.split(':')
+    if len(basicauth_part) != 2:
+        raise ValueError('BASICAUTH environment variable is not set')
+
+    basicauth_username, basicauth_password = basicauth_part
+
+    time.sleep(1)
+    if username == basicauth_username and password == basicauth_password:
+        return True
+    else:
+        time.sleep(1)
+        return False
+
+
 uvicorn.run(root_asgi_app,
-    host="0.0.0.0",
-    port=os.getenv('PORT', 8000),
+    host=HOST,
+    port=PORT,
     log_level="warning",
     ws_max_size=streamsync.serve.MAX_WEBSOCKET_MESSAGE_SIZE)

--- a/poetry.lock
+++ b/poetry.lock
@@ -258,6 +258,17 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "joblib"
+version = "1.3.2"
+description = "Lightweight pipelining with Python functions"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "joblib-1.3.2-py3-none-any.whl", hash = "sha256:ef4331c65f239985f3f2220ecc87db222f08fd22097a3dd5698f693875f8cbb9"},
+    {file = "joblib-1.3.2.tar.gz", hash = "sha256:92f865e621e17784e7955080b6d042489e3b8e294949cc44c6eac304f59772b1"},
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.21.1"
 description = "An implementation of JSON Schema validation for Python"
@@ -953,6 +964,90 @@ files = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.4.1.post1"
+description = "A set of python modules for machine learning and data mining"
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "scikit-learn-1.4.1.post1.tar.gz", hash = "sha256:93d3d496ff1965470f9977d05e5ec3376fb1e63b10e4fda5e39d23c2d8969a30"},
+    {file = "scikit_learn-1.4.1.post1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c540aaf44729ab5cd4bd5e394f2b375e65ceaea9cdd8c195788e70433d91bbc5"},
+    {file = "scikit_learn-1.4.1.post1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:4310bff71aa98b45b46cd26fa641309deb73a5d1c0461d181587ad4f30ea3c36"},
+    {file = "scikit_learn-1.4.1.post1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f43dd527dabff5521af2786a2f8de5ba381e182ec7292663508901cf6ceaf6e"},
+    {file = "scikit_learn-1.4.1.post1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c02e27d65b0c7dc32f2c5eb601aaf5530b7a02bfbe92438188624524878336f2"},
+    {file = "scikit_learn-1.4.1.post1-cp310-cp310-win_amd64.whl", hash = "sha256:629e09f772ad42f657ca60a1a52342eef786218dd20cf1369a3b8d085e55ef8f"},
+    {file = "scikit_learn-1.4.1.post1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6145dfd9605b0b50ae72cdf72b61a2acd87501369a763b0d73d004710ebb76b5"},
+    {file = "scikit_learn-1.4.1.post1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:1afed6951bc9d2053c6ee9a518a466cbc9b07c6a3f9d43bfe734192b6125d508"},
+    {file = "scikit_learn-1.4.1.post1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce03506ccf5f96b7e9030fea7eb148999b254c44c10182ac55857bc9b5d4815f"},
+    {file = "scikit_learn-1.4.1.post1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4ba516fcdc73d60e7f48cbb0bccb9acbdb21807de3651531208aac73c758e3ab"},
+    {file = "scikit_learn-1.4.1.post1-cp311-cp311-win_amd64.whl", hash = "sha256:78cd27b4669513b50db4f683ef41ea35b5dddc797bd2bbd990d49897fd1c8a46"},
+    {file = "scikit_learn-1.4.1.post1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:a1e289f33f613cefe6707dead50db31930530dc386b6ccff176c786335a7b01c"},
+    {file = "scikit_learn-1.4.1.post1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:0df87de9ce1c0140f2818beef310fb2e2afdc1e66fc9ad587965577f17733649"},
+    {file = "scikit_learn-1.4.1.post1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:712c1c69c45b58ef21635360b3d0a680ff7d83ac95b6f9b82cf9294070cda710"},
+    {file = "scikit_learn-1.4.1.post1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1754b0c2409d6ed5a3380512d0adcf182a01363c669033a2b55cca429ed86a81"},
+    {file = "scikit_learn-1.4.1.post1-cp312-cp312-win_amd64.whl", hash = "sha256:1d491ef66e37f4e812db7e6c8286520c2c3fc61b34bf5e59b67b4ce528de93af"},
+    {file = "scikit_learn-1.4.1.post1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:aa0029b78ef59af22cfbd833e8ace8526e4df90212db7ceccbea582ebb5d6794"},
+    {file = "scikit_learn-1.4.1.post1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:14e4c88436ac96bf69eb6d746ac76a574c314a23c6961b7d344b38877f20fee1"},
+    {file = "scikit_learn-1.4.1.post1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7cd3a77c32879311f2aa93466d3c288c955ef71d191503cf0677c3340ae8ae0"},
+    {file = "scikit_learn-1.4.1.post1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a3ee19211ded1a52ee37b0a7b373a8bfc66f95353af058a210b692bd4cda0dd"},
+    {file = "scikit_learn-1.4.1.post1-cp39-cp39-win_amd64.whl", hash = "sha256:234b6bda70fdcae9e4abbbe028582ce99c280458665a155eed0b820599377d25"},
+]
+
+[package.dependencies]
+joblib = ">=1.2.0"
+numpy = ">=1.19.5,<2.0"
+scipy = ">=1.6.0"
+threadpoolctl = ">=2.0.0"
+
+[package.extras]
+benchmark = ["matplotlib (>=3.3.4)", "memory-profiler (>=0.57.0)", "pandas (>=1.1.5)"]
+docs = ["Pillow (>=7.1.2)", "matplotlib (>=3.3.4)", "memory-profiler (>=0.57.0)", "numpydoc (>=1.2.0)", "pandas (>=1.1.5)", "plotly (>=5.14.0)", "pooch (>=1.6.0)", "scikit-image (>=0.17.2)", "seaborn (>=0.9.0)", "sphinx (>=6.0.0)", "sphinx-copybutton (>=0.5.2)", "sphinx-gallery (>=0.15.0)", "sphinx-prompt (>=1.3.0)", "sphinxext-opengraph (>=0.4.2)"]
+examples = ["matplotlib (>=3.3.4)", "pandas (>=1.1.5)", "plotly (>=5.14.0)", "pooch (>=1.6.0)", "scikit-image (>=0.17.2)", "seaborn (>=0.9.0)"]
+tests = ["black (>=23.3.0)", "matplotlib (>=3.3.4)", "mypy (>=1.3)", "numpydoc (>=1.2.0)", "pandas (>=1.1.5)", "polars (>=0.19.12)", "pooch (>=1.6.0)", "pyamg (>=4.0.0)", "pyarrow (>=12.0.0)", "pytest (>=7.1.2)", "pytest-cov (>=2.9.0)", "ruff (>=0.0.272)", "scikit-image (>=0.17.2)"]
+
+[[package]]
+name = "scipy"
+version = "1.12.0"
+description = "Fundamental algorithms for scientific computing in Python"
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "scipy-1.12.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:78e4402e140879387187f7f25d91cc592b3501a2e51dfb320f48dfb73565f10b"},
+    {file = "scipy-1.12.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:f5f00ebaf8de24d14b8449981a2842d404152774c1a1d880c901bf454cb8e2a1"},
+    {file = "scipy-1.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e53958531a7c695ff66c2e7bb7b79560ffdc562e2051644c5576c39ff8efb563"},
+    {file = "scipy-1.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e32847e08da8d895ce09d108a494d9eb78974cf6de23063f93306a3e419960c"},
+    {file = "scipy-1.12.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4c1020cad92772bf44b8e4cdabc1df5d87376cb219742549ef69fc9fd86282dd"},
+    {file = "scipy-1.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:75ea2a144096b5e39402e2ff53a36fecfd3b960d786b7efd3c180e29c39e53f2"},
+    {file = "scipy-1.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:408c68423f9de16cb9e602528be4ce0d6312b05001f3de61fe9ec8b1263cad08"},
+    {file = "scipy-1.12.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:5adfad5dbf0163397beb4aca679187d24aec085343755fcdbdeb32b3679f254c"},
+    {file = "scipy-1.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3003652496f6e7c387b1cf63f4bb720951cfa18907e998ea551e6de51a04467"},
+    {file = "scipy-1.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b8066bce124ee5531d12a74b617d9ac0ea59245246410e19bca549656d9a40a"},
+    {file = "scipy-1.12.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8bee4993817e204d761dba10dbab0774ba5a8612e57e81319ea04d84945375ba"},
+    {file = "scipy-1.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:a24024d45ce9a675c1fb8494e8e5244efea1c7a09c60beb1eeb80373d0fecc70"},
+    {file = "scipy-1.12.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e7e76cc48638228212c747ada851ef355c2bb5e7f939e10952bc504c11f4e372"},
+    {file = "scipy-1.12.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f7ce148dffcd64ade37b2df9315541f9adad6efcaa86866ee7dd5db0c8f041c3"},
+    {file = "scipy-1.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c39f92041f490422924dfdb782527a4abddf4707616e07b021de33467f917bc"},
+    {file = "scipy-1.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7ebda398f86e56178c2fa94cad15bf457a218a54a35c2a7b4490b9f9cb2676c"},
+    {file = "scipy-1.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:95e5c750d55cf518c398a8240571b0e0782c2d5a703250872f36eaf737751338"},
+    {file = "scipy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e646d8571804a304e1da01040d21577685ce8e2db08ac58e543eaca063453e1c"},
+    {file = "scipy-1.12.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:913d6e7956c3a671de3b05ccb66b11bc293f56bfdef040583a7221d9e22a2e35"},
+    {file = "scipy-1.12.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba1b0c7256ad75401c73e4b3cf09d1f176e9bd4248f0d3112170fb2ec4db067"},
+    {file = "scipy-1.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:730badef9b827b368f351eacae2e82da414e13cf8bd5051b4bdfd720271a5371"},
+    {file = "scipy-1.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6546dc2c11a9df6926afcbdd8a3edec28566e4e785b915e849348c6dd9f3f490"},
+    {file = "scipy-1.12.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:196ebad3a4882081f62a5bf4aeb7326aa34b110e533aab23e4374fcccb0890dc"},
+    {file = "scipy-1.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:b360f1b6b2f742781299514e99ff560d1fe9bd1bff2712894b52abe528d1fd1e"},
+    {file = "scipy-1.12.0.tar.gz", hash = "sha256:4bf5abab8a36d20193c698b0f1fc282c1d083c94723902c447e5d2f1780936a3"},
+]
+
+[package.dependencies]
+numpy = ">=1.22.4,<1.29.0"
+
+[package.extras]
+dev = ["click", "cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy", "pycodestyle", "pydevtool", "rich-click", "ruff", "types-psutil", "typing_extensions"]
+doc = ["jupytext", "matplotlib (>2)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (==0.9.0)", "sphinx (!=4.1.0)", "sphinx-design (>=0.2.0)"]
+test = ["asv", "gmpy2", "hypothesis", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
@@ -1016,6 +1111,17 @@ files = [
 
 [package.extras]
 doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.3.0"
+description = "threadpoolctl"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "threadpoolctl-3.3.0-py3-none-any.whl", hash = "sha256:6155be1f4a39f31a18ea70f94a77e0ccd57dced08122ea61109e7da89883781e"},
+    {file = "threadpoolctl-3.3.0.tar.gz", hash = "sha256:5dac632b4fa2d43f42130267929af3ba01399ef4bd1882918e92dbc30365d30c"},
+]
 
 [[package]]
 name = "toml"
@@ -1239,4 +1345,4 @@ ds = ["pandas", "plotly", "pyarrow"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.2, <4.0"
-content-hash = "eda7baf2623c0f476a9d2a5ae111af040aedab615fac92e438ba18b3312ad4d9"
+content-hash = "aa4f24e605e9a6dc078ad45d3341e69040a711a6ba90c26819dcc48195d03022"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ watchdog = ">= 3.0.0, < 4"
 pandas = {version = ">= 2.2.0, < 3", optional = true}
 pyarrow = {version = ">= 15.0.0, < 16.0.0",optional = true}
 plotly = {version = ">= 5.18.0, < 6", optional = true}
+scikit-learn = {version = "^1.4.1.post1", optional = true}
 
 
 [tool.poetry.group.build]

--- a/src/streamsync/serve.py
+++ b/src/streamsync/serve.py
@@ -368,6 +368,7 @@ def get_asgi_app(
 
     server_path = os.path.dirname(__file__)
     server_static_path = pathlib.Path(server_path) / "static"
+
     if server_static_path.exists():
         asgi_app.mount(
             "/", StaticFiles(directory=str(server_static_path), html=True), name="server_static")


### PR DESCRIPTION
The integration of an app review mechanism deploys a PR on demand to test the code online or demonstrate it without requiring cloning the branch locally.

![Peek 2024-02-19 18-05](https://github.com/FabienArcellier/streamsync/assets/159559/019f624a-513c-420d-8e47-8326ec88c36e)

I used the reviewapp mechanism from [scalingo](https://scalingo.com/), a French PaaS platform. Their implementation is close to Heroku. After a first reading, project administrators will be able to trigger an environment to try and experiment on the code of the PR.

![Peek 2024-02-19 17-24](https://github.com/FabienArcellier/streamsync/assets/159559/dcc20e06-4163-4b4f-bf98-213f6e851208)

The validation environment can be modified by any visitor. If this mechanism poses a problem, we will add authentication to limit access and only offer read access for visitors.