### PR TITLE
chore: disable continuous integration on branch except for master and dev

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,6 +1,13 @@
 name: ci-macos
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'dev'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   build:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,6 +1,13 @@
 name: ci-windows
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'dev'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: ci
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'dev'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   build:


### PR DESCRIPTION
Continuous integration will only run when opening a PR or during a new commit on the major dev and master branches.