### PR TITLE
Add square barckets to evaluator regex

### DIFF
--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -743,7 +743,7 @@ class Evaluator:
     It allows for the sanitisation of frontend inputs.
     """
 
-    template_regex = re.compile(r"[\\]?@{([\w\s.]*)}")
+    template_regex = re.compile(r"[\\]?@{([\w\s.\[\]]*)}")
 
     def __init__(self, session_state: StreamsyncState, session_component_tree: ComponentTree):
         self.ss = session_state


### PR DESCRIPTION
Resolves issue #247 

A minor fix to enable the possibility of having event contexts passed through nested repeater objects where the child repeater object is the item of a parent repeater.