### PR TITLE
chore: prepare UI component handling for enhanced session and CMC integration

### DIFF
--- a/src/streamsync/app_runner.py
+++ b/src/streamsync/app_runner.py
@@ -177,6 +177,7 @@ class AppProcess(multiprocessing.Process):
         res_payload = EventResponsePayload(
             result=result,
             mutations=mutations,
+            components=session.session_component_tree.to_dict(),
             mail=mail
         )
 

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -571,7 +571,7 @@ class ComponentTree:
         for id, component in self.components.items():
             active_components[id] = component.to_dict()
         return active_components
-    
+
 
 class SessionComponentTree(ComponentTree):
 
@@ -580,10 +580,14 @@ class SessionComponentTree(ComponentTree):
         self.base_component_tree = base_component_tree
 
     def get_component(self, component_id: str) -> Optional[Component]:
-        base_component = self.base_component_tree.get_component(component_id)
-        if base_component:
-            return base_component
-        return self.components.get(component_id)
+        session_component = self.components.get(component_id, False)
+
+        if not session_component:
+            if session_component is not None:
+                # Component is removed if set to None
+                return self.base_component_tree.get_component(component_id)
+
+        return session_component
 
     def to_dict(self) -> Dict:
         active_components = {

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -580,14 +580,15 @@ class SessionComponentTree(ComponentTree):
         self.base_component_tree = base_component_tree
 
     def get_component(self, component_id: str) -> Optional[Component]:
-        session_component = self.components.get(component_id, False)
+        session_component_present = component_id in self.components
+        session_component = self.components.get(component_id)
 
-        if not session_component:
-            if session_component is not None:
-                # Component is removed if set to None
-                return self.base_component_tree.get_component(component_id)
+        if session_component_present:
+            return session_component
+                
+        return self.base_component_tree.get_component(component_id)
 
-        return session_component
+        
 
     def to_dict(self) -> Dict:
         active_components = {

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -484,7 +484,7 @@ class Component(BaseModel):
     position: int = 0
     parentId: Optional[str] = None
     handlers: Optional[Dict[str, str]] = None
-    visible: Optional[bool] = None
+    visible: Optional[bool | str] = None
     binding: Optional[Dict] = None
 
     def to_dict(self) -> Dict:

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -585,19 +585,19 @@ class SessionComponentTree(ComponentTree):
 
         if session_component_present:
             return session_component
-                
-        return self.base_component_tree.get_component(component_id)
 
-        
+        return self.base_component_tree.get_component(component_id)
 
     def to_dict(self) -> Dict:
         active_components = {
-            k: v.to_dict()
-            for k, v in self.base_component_tree.components.items()
-            }
-        for id, component in {**self.components}.items():
+            # Collecting serialized base tree components
+            component_id: base_component.to_dict()
+            for component_id, base_component
+            in self.base_component_tree.components.items()
+        }
+        for component_id, session_component in self.components.items():
             # Overriding base tree components with session-specific ones
-            active_components[id] = component.to_dict()
+            active_components[component_id] = session_component.to_dict()
         return active_components
 
 

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -484,7 +484,7 @@ class Component(BaseModel):
     position: int = 0
     parentId: Optional[str] = None
     handlers: Optional[Dict[str, str]] = None
-    visible: Optional[bool | str] = None
+    visible: Optional[Union[bool, str]] = None
     binding: Optional[Dict] = None
 
     def to_dict(self) -> Dict:

--- a/src/streamsync/ss_types.py
+++ b/src/streamsync/ss_types.py
@@ -134,6 +134,7 @@ class EventResponsePayload(BaseModel):
     result: Any
     mutations: Dict[str, Any]
     mail: List
+    components: Dict
 
 
 class StateEnquiryResponsePayload(BaseModel):

--- a/tests/testapp/ui.json
+++ b/tests/testapp/ui.json
@@ -1988,7 +1988,7 @@
                 "eventType": "ss-change",
                 "stateRef": "name"
             },
-            "visible": ""
+            "visible": false
         },
         "6e912116-4cc5-4840-96b9-84106bee795d": {
             "id": "6e912116-4cc5-4840-96b9-84106bee795d",

--- a/tests/testapp/ui.json
+++ b/tests/testapp/ui.json
@@ -1988,7 +1988,7 @@
                 "eventType": "ss-change",
                 "stateRef": "name"
             },
-            "visible": false
+            "visible": ""
         },
         "6e912116-4cc5-4840-96b9-84106bee795d": {
             "id": "6e912116-4cc5-4840-96b9-84106bee795d",

--- a/ui/src/core/index.ts
+++ b/ui/src/core/index.ts
@@ -158,7 +158,7 @@ export function generateCore() {
 		});
 	}
 
-	function updateComponents(newComponents: Record<string, any>) {
+	function ingestComponents(newComponents: Record<string, any>) {
 		if (!newComponents) return;
 		components.value = newComponents
 	}
@@ -203,7 +203,7 @@ export function generateCore() {
 			) {
 				ingestMutations(message.payload?.mutations);
 				collateMail(message.payload?.mail);
-				updateComponents(message.payload?.components);
+				ingestComponents(message.payload?.components);
 			}
 
 			const mapItem = frontendMessageMap.value.get(message.trackingId);
@@ -436,19 +436,20 @@ export function generateCore() {
 	 */
 	async function sendComponentUpdate(): Promise<void> {
 		/*
- 		Only send components created by the frontend (static), to avoid re-feeding the backend
- 		those components created by the backend.
+ 		Ensure that the backend receives only components 
+		created by the frontend (Builder-managed components, BMC), 
+		and not the components it generated (Code-managed components, CMC).
  		*/
 
- 		const staticComponents = {};
+ 		const builderManagedComponents = {};
 
  		Object.entries(components.value).forEach(([componentId, component]) => {
  			if (component.flag === 'cmc') return;
- 			staticComponents[componentId] = component;
+ 			builderManagedComponents[componentId] = component;
  		});
 
 		const payload = {
-			components: staticComponents,
+			components: builderManagedComponents,
 		};
 
 		return new Promise((resolve, reject) => {

--- a/ui/src/streamsyncTypes.ts
+++ b/ui/src/streamsyncTypes.ts
@@ -12,6 +12,7 @@ export type Component = {
 	type: string;
 	position: number;
 	content: Record<string, string>;
+	flag?: string;
 	handlers?: Record<string, string>;
 	visible?: boolean | string;
 	binding?: {


### PR DESCRIPTION
- Include session-specific component tree in EventResponse payload
- Update SessionComponentTree.to_dict to properly merge session-specific and base components, prioritizing session-specific ones
- Add optional `flag` attribute to Component class for CMC control
- Extend frontend Component type with `flag` property
- Implement Component.from_dict class method to enable deserialization
- Introduce frontend core logic to update components based on backend session tree data