### PR TITLE
chore: (minor) adding dash to template_regex in Evaluator class

### DIFF
--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -749,7 +749,7 @@ class Evaluator:
     It allows for the sanitisation of frontend inputs.
     """
 
-    template_regex = re.compile(r"[\\]?@{([\w\s.\[\]]*)}")
+    template_regex = re.compile(r"[\\]?@{([\w\s.\[\]]*)}", re.U)
 
     def __init__(self, session_state: StreamsyncState, session_component_tree: ComponentTree):
         self.ss = session_state

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -741,7 +741,6 @@ class EventDeserialiser:
             return None
 
 
-
 class Evaluator:
 
     """
@@ -749,7 +748,7 @@ class Evaluator:
     It allows for the sanitisation of frontend inputs.
     """
 
-    template_regex = re.compile(r"[\\]?@{([\w\s.\[\]]*)}", re.U)
+    template_regex = re.compile(r"[\\]?@{([\w\s.\[\]\-]*)}")
 
     def __init__(self, session_state: StreamsyncState, session_component_tree: ComponentTree):
         self.ss = session_state


### PR DESCRIPTION
Adding a dash to this regular expression enables support for "skewer-case" state property names on frontend side.