### PR TITLE
fix: send components to the frontend only upon update

### DIFF
--- a/src/streamsync/app_runner.py
+++ b/src/streamsync/app_runner.py
@@ -169,7 +169,7 @@ class AppProcess(multiprocessing.Process):
         except BaseException:
             session.session_state.add_log_entry("error",
                                                 "Serialisation Error",
-                                                f"An exception was raised during serialisation.",
+                                                "An exception was raised during serialisation.",
                                                 tb.format_exc())
 
         mail = session.session_state.mail
@@ -177,10 +177,9 @@ class AppProcess(multiprocessing.Process):
         res_payload = EventResponsePayload(
             result=result,
             mutations=mutations,
-            components=session.session_component_tree.to_dict(),
+            components=session.session_component_tree.fetch_updates(),
             mail=mail
         )
-
         session.session_state.clear_mail()
 
         return res_payload
@@ -396,7 +395,7 @@ class AppProcess(multiprocessing.Process):
             # No need to handle signal as not main thread
             pass
 
-        with concurrent.futures.ThreadPoolExecutor(100) as thread_pool:
+        with concurrent.futures.ThreadPoolExecutor(1) as thread_pool:
             self.is_app_process_server_ready.set()
             while True:  # Starts app message server
                 try:

--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -108,6 +108,7 @@ class SessionComponentTree(ComponentTree):
     def __init__(self, base_component_tree: ComponentTree):
         super().__init__(attach_root=False)
         self.base_component_tree = base_component_tree
+        self.updated = False
 
     def determine_position(self, component_id: str, parent_id: str, is_positionless: bool = False):
         session_component_present = component_id in self.components
@@ -131,6 +132,14 @@ class SessionComponentTree(ComponentTree):
         # Otherwise, try to obtain the base tree component
         return self.base_component_tree.get_component(component_id)
 
+    def attach(self, component: Component, override=False) -> None:
+        self.updated = True
+        return super().attach(component, override)
+
+    def ingest(self, serialised_components: Dict[str, Any]) -> None:
+        self.updated = True
+        return super().ingest(serialised_components)
+
     def to_dict(self) -> Dict:
         active_components = {
             # Collecting serialized base tree components
@@ -142,6 +151,12 @@ class SessionComponentTree(ComponentTree):
             # Overriding base tree components with session-specific ones
             active_components[component_id] = session_component.to_dict()
         return active_components
+
+    def fetch_updates(self):
+        if self.updated:
+            self.updated = False
+            return self.to_dict()
+        return
 
 
 class UIError(Exception):


### PR DESCRIPTION
Modified `SessionComponentTree` class with `fetch_updates` method, that'll retrieve the tree only in case if it was updated through `attach` or `ingest`. 