### PR TITLE
fix: convert all content values to strings

### DIFF
--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -1,8 +1,9 @@
+from json import dumps as json_dumps
 from typing import Optional, Union
 
 from streamsync.core import base_component_tree
-from streamsync.core_ui import (Component, SessionComponentTree,
-                                UIError, current_parent_container)
+from streamsync.core_ui import (Component, SessionComponentTree, UIError,
+                                current_parent_container)
 
 
 class StreamsyncUI:
@@ -57,6 +58,11 @@ class StreamsyncUI:
         # TODO
         return raw_binding
 
+    def _prepare_value(self, value):
+        if isinstance(value, dict):
+            return json_dumps(value)
+        return str(value)
+
     def _create_component(
             self,
             component_type: str,
@@ -78,7 +84,7 @@ class StreamsyncUI:
 
         # Converting all passed content values to strings
         raw_content = kwargs.pop("content", {})
-        content = {key: str(value) for key, value in raw_content.items()}
+        content = {key: self._prepare_value(value) for key, value in raw_content.items()}
 
         position: Optional[int] = kwargs.pop("position", None)
         is_positionless: bool = kwargs.pop("positionless", False)

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -76,6 +76,10 @@ class StreamsyncUI:
         else:
             parent_id = "root" if not parent_container else parent_container.id
 
+        # Converting all passed content values to strings
+        raw_content = kwargs.pop("content", {})
+        content = {key: str(value) for key, value in raw_content.items()}
+
         position: Optional[int] = kwargs.pop("position", None)
         is_positionless: bool = kwargs.pop("positionless", False)
         raw_handlers: dict = kwargs.pop("handlers", {})
@@ -88,6 +92,7 @@ class StreamsyncUI:
             type=component_type,
             parentId=parent_id,
             flag="cmc",
+            content=content,
             handlers=handlers,
             binding=binding,
             **kwargs


### PR DESCRIPTION
Adds a `_prepare_value` for `StreamsyncUIManager` class, to utilize inside `_create_component`. For `dict`, it uses `json.dumps`, and casts to `str` for the rest of the types. Allows to use Python types when defining content for CMCs, for example:
```py
ui.SliderInput({"minValue": 0, "maxValue": 300, "stepSize": 1}) # uses int literals
```
By default, this triggers `TypeError: template.replace is not a function` on the frontend; this fix allows to avoid it.