### PR TITLE
feat: repeater triggers exception when the last item is removed from linked state element

### DIFF
--- a/ui/src/core_components/other/CoreRepeater.vue
+++ b/ui/src/core_components/other/CoreRepeater.vue
@@ -44,6 +44,7 @@ export default {
 		const ss = inject(injectionKeys.core);
 		const componentId = inject(injectionKeys.componentId);
 		const fields = inject(injectionKeys.evaluatedFields);
+		const isBeingEdited = inject(injectionKeys.isBeingEdited);
 		const renderProxiedComponent = inject(
 			injectionKeys.renderProxiedComponent,
 		);
@@ -65,16 +66,26 @@ export default {
 		};
 
 		return () => {
+			let repeater_children = {};
+			if (
+				children.value.length != 0 &&
+				fields.repeaterObject.value != null &&
+				Object.keys(fields.repeaterObject.value).length != 0
+			) {
+				repeater_children = getRepeatedChildrenVNodes();
+			} else if (isBeingEdited.value === true) {
+				repeater_children = slots.default({});
+			} else {
+				repeater_children = {};
+			}
+
 			return h(
 				"div",
 				{
 					class: "CoreRepeater",
 					"data-streamsync-container": "",
 				},
-				children.value.length == 0 ||
-					Object.keys(fields.repeaterObject.value).length == 0
-					? slots.default({})
-					: getRepeatedChildrenVNodes(),
+				repeater_children,
 			);
 		};
 	},


### PR DESCRIPTION
The repeater is invisible when the application is running and the last element has been deleted. The default slot remains visible in edit mode.

fix #223 (maybe)

![Peek 2024-03-12 21-58](https://github.com/streamsync-cloud/streamsync/assets/159559/f565a5f4-8095-4d82-9d58-537ce6c4feae)
