### PR TITLE
chore: check if documentation is building in the continuous integration on pipeline

### DIFF
--- a/alfred/ci.py
+++ b/alfred/ci.py
@@ -11,16 +11,24 @@ import alfred
 @alfred.option('--front', '-f', help="run for frontend only", is_flag=True, default=False)
 @alfred.option('--back', '-b', help="run for backend only", is_flag=True, default=False)
 @alfred.option('--e2e', '-e', help="run for end-to-end only", default=None)
-def ci(front, back, e2e):
-    if back or (not front and not back and not e2e):
+@alfred.option('--docs', '-e', help="run for documentation only", default=False)
+def ci(front, back, e2e, docs):
+    no_options = not front and not back and not e2e and not docs
+    if back or no_options:
         alfred.invoke_command("ci.mypy")
         alfred.invoke_command("ci.pytest")
-    if front or (not front and not back and not e2e):
+
+    if front or no_options:
         alfred.invoke_command("npm.lint")
         alfred.invoke_command("npm.build")
         alfred.invoke_command("ci.codegen.ui.binding")
+
     if e2e:
         alfred.invoke_command("npm.e2e", browser=e2e)
+
+    if docs or no_options:
+        alfred.invoke_command("docs.build")
+
 
 @alfred.command("ci.mypy", help="typing checking with mypy on ./src/streamsync")
 def ci_mypy():

--- a/alfred/docs.py
+++ b/alfred/docs.py
@@ -1,0 +1,14 @@
+import alfred
+
+
+@alfred.command('docs.build', help="build documentation")
+def docs_build():
+    alfred.run("npm run docs:build")
+
+@alfred.command('docs.dev', help="start documentation dev server with hot reloading")
+def docs_dev():
+    alfred.run("npm run docs:dev")
+
+@alfred.command('docs.preview', help="preview documentation")
+def docs_preview():
+    alfred.run("npm run docs:preview")

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "docs"
   ],
   "scripts": {
-    "docs:build": "npm run -w streamsync-docs docs:build",
-    "docs:dev": "npm run -w streamsync-docs docs:dev",
-    "docs:preview": "npm run -w streamsync-docs docs:preview",
+    "docs:build": "npm run -w streamsync-docs build",
+    "docs:dev": "npm run -w streamsync-docs dev",
+    "docs:preview": "npm run -w streamsync-docs preview",
     "build": "npm run -w streamsync-ui build",
     "custom.build": "npm run -w streamsync-ui custom.build",
     "e2e": "npm run -w streamsync-e2e test",


### PR DESCRIPTION
The streamsync site build and documentation is not verified in continuous integration. I noticed that the documentation in dev currently does not build correctly.

* [x] add the command `alfred docs.build`
* [x] run the command `alfred docs.build` in `alfred ci`

![image](https://github.com/streamsync-cloud/streamsync/assets/159559/537378ad-27eb-44d1-9cf8-043e8d0a5648)
