### PR TITLE
fix: logic for determining position

### DIFF
--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -70,7 +70,7 @@ class ComponentTree:
 
         return desc
 
-    def determine_position(self, _: str, parent_id: str, is_positionless: bool = False):
+    def determine_position(self, parent_id: str, is_positionless: bool = False):
         if is_positionless:
             return -2
 
@@ -112,15 +112,15 @@ class SessionComponentTree(ComponentTree):
         self.base_component_tree = base_component_tree
         self.updated = False
 
-    def determine_position(self, component_id: str, parent_id: str, is_positionless: bool = False):
-        session_component_present = component_id in self.components
+    def determine_position(self, parent_id: str, is_positionless: bool = False):
+        session_component_present = parent_id in self.components
         if session_component_present:
             # If present, use ComponentTree method
             # for determining position directly from this class
-            return super().determine_position(component_id, parent_id, is_positionless)
+            return super().determine_position(parent_id, is_positionless)
         else:
             # Otherwise, invoke it on base component tree
-            return self.base_component_tree.determine_position(component_id, parent_id, is_positionless)
+            return self.base_component_tree.determine_position(parent_id, is_positionless)
 
     def get_component(self, component_id: str) -> Optional[Component]:
         # Check if session component tree contains requested key
@@ -163,6 +163,7 @@ class SessionComponentTree(ComponentTree):
 
 class UIError(Exception):
     ...
+
 
 @contextlib.contextmanager
 def use_component_tree(component_tree: ComponentTree):

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -97,6 +97,7 @@ def _prepare_handlers(raw_handlers: Optional[dict]):
                 handlers[event] = handler
     return handlers
 
+
 def _prepare_binding(raw_binding):
     if raw_binding is not None:
         if len(raw_binding) == 1:
@@ -155,13 +156,12 @@ def _create_component(component_tree: ComponentTree,  component_type: str, **kwa
         )
 
     # We're determining the position separately
-    # due to that we need to know whether ID of the component
+    # due to that we need to know whether parent of the component
     # is present within base component tree
     # or a session-specific one
     component.position = \
         position if position is not None else \
         component_tree.determine_position(
-            component.id,
             parent_id,
             is_positionless=is_positionless
             )


### PR DESCRIPTION
Fix for improper mechanism of determining position (using component id instead of parent id). Fixes a bug of components being "prepended" instead of "appended" to the parent.