### PR TITLE
chore: preset IDs for pages

### DIFF
--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -44,6 +44,7 @@ class ComponentTree:
 
     def __init__(self, attach_root=True) -> None:
         self.counter: int = 0
+        self.page_counter: int = 0
         self.components: Dict[str, Component] = {}
         if attach_root:
             root_component = Component(
@@ -83,6 +84,8 @@ class ComponentTree:
 
     def attach(self, component: Component, override=False) -> None:
         self.counter += 1
+        if component.type == "page":
+            self.page_counter += 1
         if (component.id in self.components) and (override is False):
             raise RuntimeWarning(f"Component with ID {component.id} already exists")
         self.components[component.id] = component
@@ -100,6 +103,8 @@ class ComponentTree:
             self.components.pop(component_id)
         for component_id, sc in serialised_components.items():
             component = Component(**sc)
+            if component.type == "page" and component_id not in self.components:
+                self.page_counter += 1
             self.components[component_id] = component
 
     def to_dict(self) -> Dict:
@@ -115,6 +120,7 @@ class SessionComponentTree(ComponentTree):
         super().__init__(attach_root=False)
         self.base_component_tree = base_component_tree
         self.updated = False
+        self.page_counter = self.base_component_tree.page_counter
 
     def determine_position(self, parent_id: str, is_positionless: bool = False):
         session_component_present = parent_id in self.components

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -74,7 +74,6 @@ class StreamsyncUI:
         component_tree = current_component_tree()
         container = _create_component(component_tree, component_type, **kwargs)
         component_tree.attach(container)
-
         return container
 
     @staticmethod
@@ -136,6 +135,13 @@ def _create_component(component_tree: ComponentTree,  component_type: str, **kwa
     # Converting all passed content values to strings
     raw_content: dict = kwargs.pop("content", {})
     content = {key: _prepare_value(value) for key, value in raw_content.items()}
+
+    if component_type == "page" and "id" not in kwargs:
+        identifier = f"cmc-page-{component_tree.page_counter + 1}"
+        if "key" not in content:
+            content["key"] = identifier
+        if "id" not in kwargs:
+            kwargs["id"] = identifier
 
     position: Optional[int] = kwargs.pop("position", None)
     is_positionless: bool = kwargs.pop("positionless", False)

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -136,6 +136,8 @@ def _create_component(component_tree: ComponentTree,  component_type: str, **kwa
     raw_content: dict = kwargs.pop("content", {})
     content = {key: _prepare_value(value) for key, value in raw_content.items()}
 
+    # A pre-defined ID is required for page components
+    # to prevent page focus loss on app reload
     if component_type == "page" and "id" not in kwargs:
         identifier = f"cmc-page-{component_tree.page_counter + 1}"
         if "key" not in content:


### PR DESCRIPTION
Adding a mechanic to keep the count of pages in component trees, and to add predefined keys & IDs for pages if case if they're not provided by user. Fixes a bug with losing CMC page focus upon app code update.