### PR TITLE
refactor: Change flag to isCodeManaged

### DIFF
--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -59,9 +59,6 @@ class ComponentTree:
                                self.components.values()))
         return children
 
-    def get_direct_descendents_length(self, parent_id):
-        return len(self.get_direct_descendents(parent_id))
-
     def get_descendents(self, parent_id: str) -> List[Component]:
         children = self.get_direct_descendents(parent_id)
         desc = children.copy()
@@ -75,8 +72,9 @@ class ComponentTree:
             return -2
 
         children = self.get_direct_descendents(parent_id)
-        if len(children) > 0:
-            position = max([0, max([child.position for child in children]) + 1])
+        cmc_children = list(filter(lambda c: c.isCodeManaged is True, children))
+        if len(cmc_children) > 0:
+            position = max([0, max([child.position for child in cmc_children]) + 1])
             return position
         else:
             return 0

--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -19,7 +19,7 @@ class Component(BaseModel):
     id: str = Field(default_factory=generate_component_id)
     type: str
     content: Dict[str, Any] = Field(default_factory=dict)
-    flag: Optional[str] = None
+    isCodeManaged: Optional[bool] = False
     position: int = 0
     parentId: Optional[str] = None
     handlers: Optional[Dict[str, str]] = None
@@ -91,7 +91,7 @@ class ComponentTree:
         removed_ids = [
             key for key, value in self.components.items()
             if key not in serialised_components.keys()
-            and value.flag != "cmc"
+            and value.isCodeManaged is False
         ]
 
         for component_id in removed_ids:

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -148,7 +148,7 @@ def _create_component(component_tree: ComponentTree,  component_type: str, **kwa
     component = Component(
         type=component_type,
         parentId=parent_id,
-        flag="cmc",
+        isCodeManaged=True,
         content=content,
         handlers=handlers,
         binding=binding,

--- a/ui/src/builder/BuilderSettings.vue
+++ b/ui/src/builder/BuilderSettings.vue
@@ -74,7 +74,7 @@ const ssbm = inject(injectionKeys.builderManager);
 const docsActive = ref(false);
 
 const component = computed(() => ss.getComponentById(ssbm.getSelectedId()));
-const readonly = computed(() => component.value.flag === "cmc");
+const readonly = computed(() => component.value.isCodeManaged);
 
 const componentDefinition = computed(() => {
 	const { type } = component.value;

--- a/ui/src/builder/BuilderSidebarTree.vue
+++ b/ui/src/builder/BuilderSidebarTree.vue
@@ -81,7 +81,7 @@ const isSearchActive: Ref<boolean> = ref(false);
 const searchQuery: Ref<string> = ref(null);
 const matchIndex: Ref<number> = ref(-1);
 const rootComponents = computed(() => {
-	return ss.getComponents(null, true);
+	return ss.getComponents(null, { sortedByPosition: true });
 });
 
 async function toggleSearch() {

--- a/ui/src/builder/BuilderTreeBranch.vue
+++ b/ui/src/builder/BuilderTreeBranch.vue
@@ -165,7 +165,7 @@ const summaryText = computed(() => {
 });
 
 const childrenComponents = computed(() => {
-	return ss.getComponents(componentId.value, true);
+	return ss.getComponents(componentId.value, { sortedByPosition: true });
 });
 
 const childrenVisible = ref(true);

--- a/ui/src/builder/BuilderTreeBranch.vue
+++ b/ui/src/builder/BuilderTreeBranch.vue
@@ -40,7 +40,7 @@
 			<template v-if="!isComponentVisible(component.id)">
 				&nbsp;&middot;&nbsp;<i class="ri-eye-off-line ri-lg"></i>
 			</template>
-			<template v-if="cmc">
+			<template v-if="component.isCodeManaged">
 				&nbsp;&middot;&nbsp;<i class="ri-file-code-line ri-lg"></i>
 			</template>
 
@@ -51,7 +51,7 @@
 		<div v-if="childrenVisible && !childless" class="children">
 			<div
 				v-for="childComponent in childrenComponents.filter(
-					(c) => c.flag !== 'cmc',
+					(c) => !c.isCodeManaged,
 				)"
 				:key="childComponent.id"
 				class="child"
@@ -63,7 +63,7 @@
 			</div>
 			<div
 				v-for="childComponent in childrenComponents.filter(
-					(c) => c.flag === 'cmc',
+					(c) => c.isCodeManaged,
 				)"
 				:key="childComponent.id"
 				class="child"
@@ -116,8 +116,6 @@ const rootEl: Ref<HTMLElement> = ref(null);
 const componentDefinition = computed(() =>
 	ss.getComponentDefinition(component.value.type),
 );
-
-const cmc = computed(() => component.value?.flag === "cmc");
 
 const name = computed(() => {
 	const name =

--- a/ui/src/builder/useComponentActions.ts
+++ b/ui/src/builder/useComponentActions.ts
@@ -35,7 +35,7 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 		if (!parent) return;
 
 		const previousSibling = ss
-			.getComponents(parent.id)
+			.getComponents(parent.id, { includeBMC: true, includeCMC: false })
 			.filter((c) => c.position == position - 1)[0];
 
 		// MUTATIONS
@@ -67,7 +67,7 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 		if (position == -2) return; // Positionless
 
 		const positionfulSiblings = ss
-			.getComponents(parent.id)
+			.getComponents(parent.id, { includeBMC: true, includeCMC: false })
 			.filter((c) => c.position !== -2);
 		if (position >= positionfulSiblings.length - 1) {
 			return;
@@ -190,7 +190,10 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 		).positionless;
 		if (positionless) return;
 		const siblings = ss
-			.getComponentChildren(component.parentId, true, false)
+			.getComponents(component.parentId, {
+				includeBMC: true,
+				includeCMC: false,
+			})
 			.filter((c) => c.id !== componentId);
 		const higherSiblings = siblings.filter(
 			(siblingComponent) =>
@@ -395,7 +398,10 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 	 */
 	function getEnabledMoves(targetId: Component["id"]) {
 		const getPositionableChildrenCount = (parentId: Component["id"]) => {
-			const children = ss.getComponentChildren(parentId, true, false);
+			const children = ss.getComponents(parentId, {
+				includeBMC: true,
+				includeCMC: false,
+			});
 			const positionableChildren = children.filter((c) => {
 				const positionless = ss.getComponentDefinition(
 					c.type,
@@ -572,7 +578,10 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 		}
 
 		const positionfulChildren = ss
-			.getComponentChildren(targetParentId, true, false)
+			.getComponents(targetParentId, {
+				includeBMC: true,
+				includeCMC: false,
+			})
 			.filter((c) => c.position !== -2);
 
 		if (positionfulChildren.length > 0) {

--- a/ui/src/builder/useComponentActions.ts
+++ b/ui/src/builder/useComponentActions.ts
@@ -190,7 +190,7 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 		).positionless;
 		if (positionless) return;
 		const siblings = ss
-			.getComponents(component.parentId)
+			.getComponentChildren(component.parentId, true, false)
 			.filter((c) => c.id !== componentId);
 		const higherSiblings = siblings.filter(
 			(siblingComponent) =>
@@ -261,7 +261,7 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 	 */
 	function isDraggingAllowed(targetId: Component["id"]): boolean {
 		const component = ss.getComponentById(targetId);
-		return !isRoot(targetId) && component?.flag !== "cmc";
+		return !isRoot(targetId) && !component?.isCodeManaged;
 	}
 
 	/**
@@ -270,7 +270,7 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 	function isAddAllowed(targetId: Component["id"]): boolean {
 		const component = ss.getComponentById(targetId);
 		return (
-			component?.flag !== "cmc" &&
+			!component?.isCodeManaged &&
 			ss.getContainableTypes(targetId).length > 0
 		);
 	}
@@ -287,7 +287,7 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 	 */
 	function isCutAllowed(targetId: Component["id"]): boolean {
 		const component = ss.getComponentById(targetId);
-		return !isRoot(targetId) && component?.flag !== "cmc";
+		return !isRoot(targetId) && !component?.isCodeManaged;
 	}
 
 	/**
@@ -295,7 +295,7 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 	 */
 	function isDeleteAllowed(targetId: Component["id"]): boolean {
 		const component = ss.getComponentById(targetId);
-		return !isRoot(targetId) && component?.flag !== "cmc";
+		return !isRoot(targetId) && !component?.isCodeManaged;
 	}
 
 	/**
@@ -374,7 +374,7 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 	 */
 	function isPasteAllowed(targetId: Component["id"]): boolean {
 		const component = ss.getComponentById(targetId);
-		if (!component || component.flag === "cmc") return false;
+		if (!component || component.isCodeManaged) return false;
 		const clipboard = ssbm.getClipboard();
 		if (clipboard === null) return false;
 		const { jsonSubtree } = clipboard;
@@ -395,20 +395,19 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 	 */
 	function getEnabledMoves(targetId: Component["id"]) {
 		const getPositionableChildrenCount = (parentId: Component["id"]) => {
-			const children = ss.getComponents(parentId);
+			const children = ss.getComponentChildren(parentId, true, false);
 			const positionableChildren = children.filter((c) => {
-				const component = ss.getComponentById(c.id);
 				const positionless = ss.getComponentDefinition(
 					c.type,
 				)?.positionless;
-				if (positionless || component.flag === "cmc") return false;
+				if (positionless) return false;
 				return true;
 			});
 			return positionableChildren.length;
 		};
 
 		const component = ss.getComponentById(targetId);
-		if (!component || component.flag === "cmc") {
+		if (!component || component.isCodeManaged) {
 			return { up: false, down: false };
 		}
 		const definition = ss.getComponentDefinition(component.type);
@@ -449,7 +448,7 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 			JSON.stringify(subtree),
 		);
 		deepCopiedSubtree.forEach((c) => {
-			delete c.flag;
+			delete c.isCodeManaged;
 			const newId = generateNewComponentId();
 			deepCopiedSubtree
 				.filter((nc) => nc.id !== c.id)
@@ -572,11 +571,15 @@ export function useComponentActions(ss: Core, ssbm: BuilderManager) {
 			return -2;
 		}
 
-		const children = ss.getComponents(targetParentId);
+		const positionfulChildren = ss
+			.getComponentChildren(targetParentId, true, false)
+			.filter((c) => c.position !== -2);
 
-		if (children.length > 0) {
+		if (positionfulChildren.length > 0) {
 			const position = Math.max(
-				Math.max(...children.map((c: Component) => c.position)) + 1,
+				Math.max(
+					...positionfulChildren.map((c: Component) => c.position),
+				) + 1,
 				0,
 			);
 			return position;

--- a/ui/src/builder/useDragDropComponent.ts
+++ b/ui/src/builder/useDragDropComponent.ts
@@ -81,7 +81,7 @@ export function useDragDropComponent(ss: Core) {
 		if (!targetComponent) return false;
 		const containableTypes = ss.getContainableTypes(targetId);
 		return (
-			targetComponent?.flag !== "cmc" &&
+			!targetComponent?.isCodeManaged &&
 			!ss.isChildOf(draggedId, targetId) &&
 			containableTypes.includes(draggedType)
 		);

--- a/ui/src/core/auditAndFix.ts
+++ b/ui/src/core/auditAndFix.ts
@@ -97,7 +97,10 @@ function auditAndFixPositions(
 	}
 
 	const positionfulChildren = Object.values(components).filter(
-		(c) => c.parentId === component.id && c.position !== -2,
+		(c) =>
+			c.parentId === component.id &&
+			c.position !== -2 &&
+			!c.isCodeManaged,
 	);
 	let positionSum = 0;
 	positionfulChildren.forEach((c) => {

--- a/ui/src/core/index.ts
+++ b/ui/src/core/index.ts
@@ -510,6 +510,8 @@ export function generateCore() {
 	 * Gets children of a specific Streamsync component.
 	 *
 	 * @param parentId The parent id.
+	 * @param includeBMC Whether to include Builder-managed components
+	 * @param includeCMC Whether to include code-managed components
 	 * @returns An array of components.
 	 */
 	function getComponentChildren(
@@ -525,7 +527,11 @@ export function generateCore() {
 			const isBMC = !isCMC;
 			return (includeBMC && isBMC) || (includeCMC && isCMC);
 		});
-		ca = ca.sort((a, b) => (a.position > b.position ? 1 : -1));
+		ca = ca.sort((a, b) => {
+			if (a.isCodeManaged && !b.isCodeManaged) return 1;
+			if (!a.isCodeManaged && b.isCodeManaged) return -1;
+			return a.position > b.position ? 1 : -1;
+		});
 
 		return ca;
 	}

--- a/ui/src/core/index.ts
+++ b/ui/src/core/index.ts
@@ -485,53 +485,65 @@ export function generateCore() {
 	}
 
 	/**
-	 * Gets registered Streamsync components.
+	 * 
 	 *
-	 * @param childrenOfId If specified, only include results that are children of a component with this id.
+	 * @param childrenOfId 
 	 * @param sortedByPosition Whether to sort the components by position or return in random order.
 	 * @returns An array of components.
 	 */
-	function getComponents(
-		childrenOfId: Component["id"] = undefined,
-		sortedByPosition: boolean = false,
-	): Component[] {
-		let ca = Object.values(components.value);
+	// function getComponents(
+	// 	childrenOfId: Component["id"] = undefined,
+	// 	sortedByPosition: boolean = false,
+	// ): Component[] {
+	// 	let ca = Object.values(components.value);
 
-		if (typeof childrenOfId != "undefined") {
-			ca = ca.filter((c) => c.parentId == childrenOfId);
-		}
-		if (sortedByPosition) {
-			ca = ca.sort((a, b) => (a.position > b.position ? 1 : -1));
-		}
-		return ca;
-	}
+	// 	if (typeof childrenOfId != "undefined") {
+	// 		ca = ca.filter((c) => c.parentId == childrenOfId);
+	// 	}
+	// 	if (sortedByPosition) {
+	// 		ca = ca.sort((a, b) => (a.position > b.position ? 1 : -1));
+	// 	}
+	// 	return ca;
+	// }
 
 	/**
-	 * Gets children of a specific Streamsync component.
+	 * Gets registered Streamsync components.
 	 *
-	 * @param parentId The parent id.
-	 * @param includeBMC Whether to include Builder-managed components
-	 * @param includeCMC Whether to include code-managed components
+	 * @param parentId If specified, only include results that are children of a component with this id.
+	 * @param param1 Whether to include Builder-managed components and code-managed components, and whether to sort.
 	 * @returns An array of components.
 	 */
-	function getComponentChildren(
-		parentId: Component["id"],
-		includeBMC: boolean = true,
-		includeCMC: boolean = true,
+	function getComponents(
+		parentId?: Component["id"],
+		{
+			includeBMC = true,
+			includeCMC = true,
+			sortedByPosition = false,
+		}: {
+			includeBMC?: boolean;
+			includeCMC?: boolean;
+			sortedByPosition?: boolean;
+		} = {},
 	): Component[] {
 		let ca = Object.values(components.value);
 
-		ca = ca.filter((c) => c.parentId == parentId);
+		if (typeof parentId !== "undefined") {
+			ca = ca.filter((c) => c.parentId == parentId);
+		}
+
 		ca = ca.filter((c) => {
 			const isCMC = c.isCodeManaged;
 			const isBMC = !isCMC;
 			return (includeBMC && isBMC) || (includeCMC && isCMC);
 		});
-		ca = ca.sort((a, b) => {
-			if (a.isCodeManaged && !b.isCodeManaged) return 1;
-			if (!a.isCodeManaged && b.isCodeManaged) return -1;
-			return a.position > b.position ? 1 : -1;
-		});
+
+		if (sortedByPosition) {
+			ca = ca.sort((a, b) => {
+				if (a.isCodeManaged && !b.isCodeManaged) return 1;
+				if (!a.isCodeManaged && b.isCodeManaged) return -1;
+				return a.position > b.position ? 1 : -1;
+			});
+		}
 
 		return ca;
 	}
@@ -597,7 +609,6 @@ export function generateCore() {
 		getSessionTimestamp,
 		getUserState,
 		isChildOf,
-		getComponentChildren,
 	};
 
 	return core;

--- a/ui/src/core/index.ts
+++ b/ui/src/core/index.ts
@@ -160,7 +160,7 @@ export function generateCore() {
 
 	function ingestComponents(newComponents: Record<string, any>) {
 		if (!newComponents) return;
-		components.value = newComponents
+		components.value = newComponents;
 	}
 
 	function clearFrontendMap() {
@@ -441,12 +441,12 @@ export function generateCore() {
 		and not the components it generated (Code-managed components, CMC).
  		*/
 
- 		const builderManagedComponents = {};
+		const builderManagedComponents = {};
 
- 		Object.entries(components.value).forEach(([componentId, component]) => {
- 			if (component.flag === 'cmc') return;
- 			builderManagedComponents[componentId] = component;
- 		});
+		Object.entries(components.value).forEach(([componentId, component]) => {
+			if (component.isCodeManaged) return;
+			builderManagedComponents[componentId] = component;
+		});
 
 		const payload = {
 			components: builderManagedComponents,
@@ -480,7 +480,7 @@ export function generateCore() {
 		do {
 			if (child.parentId == parentId) return true;
 			child = components.value[child.parentId];
-		} while(child);
+		} while (child);
 		return false;
 	}
 
@@ -503,6 +503,30 @@ export function generateCore() {
 		if (sortedByPosition) {
 			ca = ca.sort((a, b) => (a.position > b.position ? 1 : -1));
 		}
+		return ca;
+	}
+
+	/**
+	 * Gets children of a specific Streamsync component.
+	 *
+	 * @param parentId The parent id.
+	 * @returns An array of components.
+	 */
+	function getComponentChildren(
+		parentId: Component["id"],
+		includeBMC: boolean = true,
+		includeCMC: boolean = true,
+	): Component[] {
+		let ca = Object.values(components.value);
+
+		ca = ca.filter((c) => c.parentId == parentId);
+		ca = ca.filter((c) => {
+			const isCMC = c.isCodeManaged;
+			const isBMC = !isCMC;
+			return (includeBMC && isBMC) || (includeCMC && isCMC);
+		});
+		ca = ca.sort((a, b) => (a.position > b.position ? 1 : -1));
+
 		return ca;
 	}
 
@@ -567,6 +591,7 @@ export function generateCore() {
 		getSessionTimestamp,
 		getUserState,
 		isChildOf,
+		getComponentChildren,
 	};
 
 	return core;

--- a/ui/src/core_components/content/CoreLink.vue
+++ b/ui/src/core_components/content/CoreLink.vue
@@ -28,7 +28,7 @@ export default {
 				options: (ss: Core) => {
 					return Object.fromEntries(
 						ss
-							.getComponents("root", true)
+							.getComponents("root", { sortedByPosition: true })
 							.map((page) => page.content.key)
 							.filter((key) => Boolean(key))
 							.map((key) => [`#${key}`, `Page with key: ${key}`]),

--- a/ui/src/core_components/other/CoreRepeater.vue
+++ b/ui/src/core_components/other/CoreRepeater.vue
@@ -48,7 +48,9 @@ export default {
 			injectionKeys.renderProxiedComponent,
 		);
 
-		const children = computed(() => ss.getComponents(componentId, true));
+		const children = computed(() =>
+			ss.getComponents(componentId, { sortedByPosition: true }),
+		);
 		const getRepeatedChildrenVNodes = () => {
 			if (typeof fields.repeaterObject.value !== "object") {
 				return [];

--- a/ui/src/core_components/root/CoreRoot.vue
+++ b/ui/src/core_components/root/CoreRoot.vue
@@ -78,7 +78,7 @@ const rootEl: Ref<HTMLElement> = ref(null);
 const { isComponentVisible } = useEvaluator(ss);
 
 const getFirstPageId = () => {
-	const pageComponents = ss.getComponents("root", true);
+	const pageComponents = ss.getComponentChildren("root", true, true);
 	if (pageComponents.length == 0) return null;
 	const visiblePages = pageComponents.filter((c) => isComponentVisible(c.id));
 	if (visiblePages.length == 0) return null;

--- a/ui/src/core_components/root/CoreRoot.vue
+++ b/ui/src/core_components/root/CoreRoot.vue
@@ -78,7 +78,11 @@ const rootEl: Ref<HTMLElement> = ref(null);
 const { isComponentVisible } = useEvaluator(ss);
 
 const getFirstPageId = () => {
-	const pageComponents = ss.getComponentChildren("root", true, true);
+	const pageComponents = ss.getComponents("root", {
+		includeBMC: true,
+		includeCMC: true,
+		sortedByPosition: true,
+	});
 	if (pageComponents.length == 0) return null;
 	const visiblePages = pageComponents.filter((c) => isComponentVisible(c.id));
 	if (visiblePages.length == 0) return null;

--- a/ui/src/renderer/ComponentProxy.vue
+++ b/ui/src/renderer/ComponentProxy.vue
@@ -30,11 +30,10 @@ export default {
 		const isBeingEdited = computed(
 			() => !!ssbm && ssbm.getMode() != "preview",
 		);
-		const cmc = computed(() => component.value?.flag === "cmc");
 		const isDraggable = computed(
 			() =>
 				isBeingEdited.value &&
-				!cmc.value &&
+				!component.value.isCodeManaged &&
 				component.value.type !== "root",
 		);
 
@@ -87,13 +86,13 @@ export default {
 			const slotComponents = children.value.filter(componentFilter);
 
 			const bmcVNodes = slotComponents
-				.filter((c) => c.flag !== "cmc")
+				.filter((c) => !c.isCodeManaged)
 				.map((childComponent) =>
 					renderProxiedComponent(childComponent.id, instanceNumber),
 				);
 
 			const cmcVNodes = slotComponents
-				.filter((c) => c.flag === "cmc")
+				.filter((c) => c.isCodeManaged)
 				.map((childComponent) =>
 					renderProxiedComponent(childComponent.id, instanceNumber),
 				);

--- a/ui/src/renderer/ComponentProxy.vue
+++ b/ui/src/renderer/ComponentProxy.vue
@@ -26,7 +26,9 @@ export default {
 		const { getEvaluatedFields, isComponentVisible } = useEvaluator(ss);
 		const evaluatedFields = getEvaluatedFields(instancePath);
 
-		const children = computed(() => ss.getComponents(componentId, true));
+		const children = computed(() =>
+			ss.getComponents(componentId, { sortedByPosition: true }),
+		);
 		const isBeingEdited = computed(
 			() => !!ssbm && ssbm.getMode() != "preview",
 		);

--- a/ui/src/renderer/ComponentRenderer.vue
+++ b/ui/src/renderer/ComponentRenderer.vue
@@ -29,18 +29,17 @@ import { useEvaluator } from "./useEvaluator";
 
 const ss = inject(injectionKeys.core);
 const templateEvaluator = useEvaluator(ss);
-const pages: Component[] = ss.getComponents();
+const rootComponent: Component = ss.getComponentById("root");
 
-if (pages.length == 0) {
+if (!rootComponent) {
 	// eslint-disable-next-line no-console
-	console.error("No pages found.");
+	console.error("No root component found.");
 }
 
 const rootInstancePath: InstancePath = [
 	{ componentId: "root", instanceNumber: 0 },
 ];
 const rootInstanceData = [ref(null)];
-const rootComponent: Ref<Component> = ref(pages[0]);
 const rootFields = templateEvaluator.getEvaluatedFields(rootInstancePath);
 const rootStyle = computed(() => {
 	return {

--- a/ui/src/streamsyncTypes.ts
+++ b/ui/src/streamsyncTypes.ts
@@ -16,7 +16,7 @@ export type Component = {
 	type: string;
 	position: number;
 	content: Record<string, string>;
-	flag?: string;
+	isCodeManaged?: boolean;
 	handlers?: Record<string, string>;
 	visible?: boolean | string;
 	binding?: {


### PR DESCRIPTION
I refactored `flag` to `isCodeManaged` to improve readability.

Also,

**Frontend:**

Some position-related fixes:

- Insertion position in `useComponentActions` is independent of CMCs
- Higher siblings in `useComponentActions` don't have their positions incremented. Before, when inserting a BMC before a CMC, that'd increment the position of the CMC.
- AuditAndFix will ignore CMCs when fixing positioning.
- I added a more descriptive `getComponentChildren` to get children, with filters for BMC and CMC, also orders BMC first and CMC later. I intend to replace all references of `getComponents(parentId)` after release.

**Backend:**

- I made a change in the backend's `determine_position` to ignore BMCs. We now have, for example, two components with position 0, but BMCs are always rendered first.
- Removed unused `get_direct_descendents_length`