### PR TITLE
fix: Remove page from hash when it doesn't have a key

### DIFF
--- a/ui/src/core_components/root/CoreRoot.vue
+++ b/ui/src/core_components/root/CoreRoot.vue
@@ -104,7 +104,6 @@ watch(activePageId, (newPageId) => {
 		const rendererEl = document.querySelector(".ComponentRenderer");
 		rendererEl.parentElement.scrollTo(0, 0);
 	});
-	// if (!pageKey) return;
 	changePageInHash(pageKey);
 });
 

--- a/ui/src/core_components/root/CoreRoot.vue
+++ b/ui/src/core_components/root/CoreRoot.vue
@@ -104,7 +104,7 @@ watch(activePageId, (newPageId) => {
 		const rendererEl = document.querySelector(".ComponentRenderer");
 		rendererEl.parentElement.scrollTo(0, 0);
 	});
-	if (!pageKey) return;
+	// if (!pageKey) return;
 	changePageInHash(pageKey);
 });
 
@@ -120,11 +120,12 @@ function getParsedHash(): ParsedHash {
 	let routeVars: Record<string, string> = {};
 
 	if (!hashMatchGroups) return { pageKey, routeVars };
+
 	pageKey = hashMatchGroups?.pageKey
 		? decodeURIComponent(hashMatchGroups.pageKey)
 		: undefined;
-	const routeVarsSegments = hashMatchGroups.routeVars?.split("&") ?? [];
 
+	const routeVarsSegments = hashMatchGroups.routeVars?.split("&") ?? [];
 	routeVarsSegments.forEach((routeVarSegment) => {
 		const matchGroups = routeVarSegment.match(routeVarRegex)?.groups;
 		if (!matchGroups) return;


### PR DESCRIPTION
If switching from a page with a key to one without a key, the previous key would remain in the hash, causing undesired behaviour when refreshing or sharing the page.