### PR TITLE
chore:configure pypi package deployment when tagging a new release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: publish
+
+on:
+    push:
+        tags:
+            - 'v[0-9]+.[0-9]+.[0-9]+'
+            - 'v[0-9]+.[0-9]+.[0-9]+[a-z0-9]*'
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Set up Python
+              uses: actions/setup-python@v2
+
+            - name: update package manager & install python3 environment
+              run: |
+                pip install poetry
+                poetry install
+
+            - name: run continuous integration to check everything is fine
+              run: |
+                poetry run alfred ci
+
+            - name: publish on pypi
+              run: |
+                poetry run alfred publish.pypi
+              env:
+                  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/alfred/publish.py
+++ b/alfred/publish.py
@@ -1,0 +1,83 @@
+"""
+The publish module contains the commands to carry out the deployment.
+
+The alfred publish command creates a new tag that triggers the deployment pipeline.
+"""
+import os
+import sys
+
+import alfred
+import click
+from click import Choice
+
+ROOT_DIR = os.path.realpath(os.path.join(__file__, "..", ".."))
+
+@alfred.command("publish", help="tag a new release and trigger pypi publication")
+def publish():
+    """
+    tag a release of fixtup and release through github actions
+
+    Before running the command, it checks if the branch is on master, if the branch is up to date with origin/master.
+
+    >>> $ alfred publish
+    """
+    import streamsync
+    VERSION = f"v{streamsync.VERSION}"
+
+    git = alfred.sh("git", "git should be present")
+    os.chdir(ROOT_DIR)
+
+    # update the existing tags
+    alfred.run(git, ["fetch"])
+
+    _, stdout, _ = alfred.run(git, ["describe", "--tags", "--abbrev=0"])
+    current_version = stdout.strip()
+
+    _, stdout, _ = alfred.run(git, ["status"])
+    git_status = stdout.strip()
+
+    on_master = "On branch master" in git_status
+    if not on_master:
+        click.echo(click.style("Branch should be on master, use git checkout master", fg="red"))
+        click.echo(git_status.strip()[0])
+        sys.exit(1)
+
+    up_to_date = "Your branch is up to date with 'origin/master'" in git_status
+    if not up_to_date:
+        click.echo(click.style("Branch should be up to date with origin/master, push your change to repository", fg="red"))
+        sys.exit(1)
+
+    non_commited_changes = "Changes not staged for commit" in git_status or "Changes to be committed" in git_status
+    if non_commited_changes:
+        click.echo(click.style("Changes in progress, can't release a new version", fg="red"))
+        sys.exit(1)
+
+    if current_version == VERSION:
+        click.echo(click.style(f"Version {VERSION} already exists, update version in pyproject.toml", fg='red'))
+        sys.exit(1)
+
+    click.echo("")
+    click.echo(f"Next release {VERSION} (current: {current_version})")
+    click.echo("")
+    value = click.prompt("Confirm", type=Choice(['y', 'n']), show_choices=True, default='n')
+
+    if value == 'y':
+        alfred.run(git, ['tag', VERSION])
+        alfred.run(git, ['push', 'origin', VERSION])
+
+
+@alfred.command("publish.pypi", help="publish the package on pypi", hidden=True)
+def publish_pypi():
+    """
+    publish the package on pypi using poetry. This command is run with github actions.
+
+    You can run it from local. You should set PYPI_TOKEN environment variable with your pypi token
+    to run it in local.
+    """
+    pypi_token = os.getenv('PYPI_TOKEN', None)
+    if pypi_token is not None:
+        alfred.run(f"poetry config pypi-token.pypi {pypi_token}")
+        alfred.run("poetry publish --build")
+    else:
+        click.echo(click.style("PYPI_TOKEN is not set as environment variable", fg='red'))
+        sys.exit(1)


### PR DESCRIPTION
The command `alfred publish` will trigger a new release of pypi package.

* check it's on master
* check there is no waiting change in master
* check the version number in the manifest has changed
* ask confirmation about the version number related to the previous one
* create a tag and push the tag to the repo

The deployment is trigger on github action

* run the CI a last time to check everything is ok (for exemple, check ui binding generation)
* publish the package on pypi