### PR TITLE
feat: check CMC parent-child relations

### DIFF
--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -137,13 +137,17 @@ def _check_parent_child_relations(
             )
 
     valid_children_types_for_parent = \
-        StreamsyncUIManager.children_types_map.get(parent.type)
+        StreamsyncUIManager.children_types_map.get(parent.type, [])
 
     while "inherit" in valid_children_types_for_parent:
         # Switch to grandparent allowed types in case of "inherit" instruction
+        if not parent.parentId:
+            break
         grandparent = component_tree.get_component(parent.parentId)
+        if not grandparent:
+            break
         valid_children_types_for_parent = \
-            StreamsyncUIManager.children_types_map.get(grandparent.type)
+            StreamsyncUIManager.children_types_map.get(grandparent.type, [])
 
     valid_parent_types_for_component = \
         StreamsyncUIManager.parent_types_map.get(component_type)

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -127,6 +127,9 @@ def _check_parent_child_relations(
     # but importing it directly causes a circular import
     from streamsync.ui import StreamsyncUIManager
 
+    if component_type == "root":
+        raise UIError("Root component cannot be a child component.")
+
     parent = component_tree.get_component(parent_id)
     if not parent:
         raise RuntimeError(
@@ -148,11 +151,15 @@ def _check_parent_child_relations(
             "in allowed types map."
             )
 
-    is_component_a_valid_child = \
-        component_type in valid_children_types_for_parent \
-        and parent.type in valid_parent_types_for_component
+    is_component_eligible = \
+        (component_type in valid_children_types_for_parent
+         or '*' in valid_children_types_for_parent)
 
-    return is_component_a_valid_child
+    is_parent_eligible = \
+        (parent.type in valid_parent_types_for_component
+         or '*' in valid_parent_types_for_component)
+
+    return is_component_eligible and is_parent_eligible
 
 
 def _create_component(

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -138,6 +138,13 @@ def _check_parent_child_relations(
 
     valid_children_types_for_parent = \
         StreamsyncUIManager.children_types_map.get(parent.type)
+
+    if "inherit" in valid_children_types_for_parent:
+        # Switch to grandparent allowed types in case of "inherit" instruction
+        grandparent = component_tree.get_component(parent.parentId)
+        valid_children_types_for_parent = \
+            StreamsyncUIManager.children_types_map.get(grandparent.type)
+
     valid_parent_types_for_component = \
         StreamsyncUIManager.parent_types_map.get(component_type)
 

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -139,15 +139,17 @@ def _check_parent_child_relations(
     valid_children_types_for_parent = \
         StreamsyncUIManager.children_types_map.get(parent.type, [])
 
+    retrieval_id = parent.parentId
     while "inherit" in valid_children_types_for_parent:
         # Switch to grandparent allowed types in case of "inherit" instruction
-        if not parent.parentId:
+        if not retrieval_id:
             break
-        grandparent = component_tree.get_component(parent.parentId)
+        grandparent = component_tree.get_component(retrieval_id)
         if not grandparent:
             break
         valid_children_types_for_parent = \
             StreamsyncUIManager.children_types_map.get(grandparent.type, [])
+        retrieval_id = grandparent.parentId
 
     valid_parent_types_for_component = \
         StreamsyncUIManager.parent_types_map.get(component_type)

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -139,7 +139,7 @@ def _check_parent_child_relations(
     valid_children_types_for_parent = \
         StreamsyncUIManager.children_types_map.get(parent.type)
 
-    if "inherit" in valid_children_types_for_parent:
+    while "inherit" in valid_children_types_for_parent:
         # Switch to grandparent allowed types in case of "inherit" instruction
         grandparent = component_tree.get_component(parent.parentId)
         valid_children_types_for_parent = \


### PR DESCRIPTION
Depends on #335 

Verifies whether a CMC can be a valid child for provided `parent_id`, and whether a parent component associated with this id can be a valid parent for the CMC.