### PR TITLE
chore: removed unnecessary import

### DIFF
--- a/ui/src/renderer/RenderError.vue
+++ b/ui/src/renderer/RenderError.vue
@@ -10,7 +10,6 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps } from "vue";
 import { Component } from "../streamsyncTypes";
 
 interface Props {


### PR DESCRIPTION
This was causing this warning:
```
[@vue/compiler-sfc] `defineProps` is a compiler macro and no longer needs to be imported.
```