### PR TITLE
refact: proposal for a new design arround component tree

### DIFF
--- a/src/streamsync/__init__.py
+++ b/src/streamsync/__init__.py
@@ -9,7 +9,6 @@ from streamsync.core import (
     Readable,
     State,
     StreamsyncState,
-    base_cmc_tree,
     base_component_tree,
     initial_state,
     new_initial_state,
@@ -21,7 +20,6 @@ from streamsync.ui import StreamsyncUIManager
 VERSION = importlib.metadata.version("streamsync")
 
 base_component_tree
-base_cmc_tree
 session_manager
 Config
 session_verifier

--- a/src/streamsync/app_runner.py
+++ b/src/streamsync/app_runner.py
@@ -20,7 +20,7 @@ from watchdog.observers.polling import PollingObserver
 
 from streamsync import VERSION
 from streamsync.core import EventHandlerRegistry, StreamsyncSession
-from streamsync.core_ui import injest_bmc_component_tree
+from streamsync.core_ui import ingest_bmc_component_tree
 from streamsync.ss_types import (
     AppProcessServerRequest,
     AppProcessServerRequestPacket,
@@ -206,7 +206,7 @@ class AppProcess(multiprocessing.Process):
     
     def _handle_component_update(self, payload: ComponentUpdateRequestPayload) -> None:
         import streamsync
-        injest_bmc_component_tree(streamsync.base_component_tree, payload.components)
+        ingest_bmc_component_tree(streamsync.base_component_tree, payload.components)
 
     def _handle_message(self, session_id: str, request: AppProcessServerRequest) -> AppProcessServerResponse:
         """
@@ -324,7 +324,7 @@ class AppProcess(multiprocessing.Process):
         terminate_early = False
 
         try:
-            injest_bmc_component_tree(streamsync.base_component_tree, self.bmc_components)
+            ingest_bmc_component_tree(streamsync.base_component_tree, self.bmc_components)
         except BaseException:
             streamsync.core.initial_state.add_log_entry(
                 "error", "UI Components Error", "Couldn't load components. An exception was raised.", tb.format_exc())

--- a/src/streamsync/app_runner.py
+++ b/src/streamsync/app_runner.py
@@ -15,12 +15,12 @@ from types import ModuleType
 from typing import Callable, Dict, List, Optional, cast
 
 import watchdog.events
-import watchdog.observers
 from pydantic import ValidationError
 from watchdog.observers.polling import PollingObserver
 
 from streamsync import VERSION
 from streamsync.core import EventHandlerRegistry, StreamsyncSession
+from streamsync.core_ui import injest_bmc_component_tree
 from streamsync.ss_types import (
     AppProcessServerRequest,
     AppProcessServerRequestPacket,
@@ -206,13 +206,12 @@ class AppProcess(multiprocessing.Process):
     
     def _handle_component_update(self, payload: ComponentUpdateRequestPayload) -> None:
         import streamsync
-        streamsync.base_component_tree.ingest(payload.components)
+        injest_bmc_component_tree(streamsync.base_component_tree, payload.components)
 
     def _handle_message(self, session_id: str, request: AppProcessServerRequest) -> AppProcessServerResponse:
         """
         Handles messages from the main process to the app's isolated process.
         """
-
         import streamsync
 
         session = None
@@ -325,7 +324,7 @@ class AppProcess(multiprocessing.Process):
         terminate_early = False
 
         try:
-            streamsync.base_component_tree.ingest(self.bmc_components)
+            injest_bmc_component_tree(streamsync.base_component_tree, self.bmc_components)
         except BaseException:
             streamsync.core.initial_state.add_log_entry(
                 "error", "UI Components Error", "Couldn't load components. An exception was raised.", tb.format_exc())

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -35,12 +35,7 @@ from typing import (
     cast,
 )
 
-from streamsync.core_ui import (
-    ComponentTree,
-    DependentComponentTree,
-    SessionComponentTree,
-    use_component_tree,
-)
+from streamsync import core_ui
 from streamsync.ss_types import (
     InstancePath,
     Readable,
@@ -832,7 +827,7 @@ class EventDeserialiser:
     Its main goal is to deserialise incoming content in a controlled and predictable way,
     applying sanitisation of inputs where relevant."""
 
-    def __init__(self, session_state: StreamsyncState, session_component_tree: SessionComponentTree):
+    def __init__(self, session_state: StreamsyncState, session_component_tree: core_ui.ComponentTree):
         self.evaluator = Evaluator(session_state, session_component_tree)
 
     def transform(self, ev: StreamsyncEvent) -> None:
@@ -1019,7 +1014,7 @@ class Evaluator:
 
     template_regex = re.compile(r"[\\]?@{([^{]*)}")
 
-    def __init__(self, session_state: StreamsyncState, session_component_tree: ComponentTree):
+    def __init__(self, session_state: StreamsyncState, session_component_tree: core_ui.ComponentTree):
         self.ss = session_state
         self.ct = session_component_tree
 
@@ -1181,7 +1176,7 @@ class StreamsyncSession:
         new_state = StreamsyncState.get_new()
         new_state.user_state.mutated = set()
         self.session_state = new_state
-        self.session_component_tree = SessionComponentTree(base_component_tree, base_cmc_tree)
+        self.session_component_tree = core_ui.build_session_component_tree(base_component_tree)
         self.event_handler = EventHandler(self)
 
     def update_last_active_timestamp(self) -> None:
@@ -1353,7 +1348,7 @@ class EventHandler:
                 arg_values.append(ui_manager)
 
         result = None
-        with use_component_tree(self.session.session_component_tree):
+        with core_ui.use_component_tree(self.session.session_component_tree):
             if is_async_handler:
                 result, captured_stdout = self._async_handler_executor(callable_handler, arg_values)
             else:
@@ -1476,11 +1471,17 @@ def session_verifier(func: Callable) -> Callable:
     session_manager.add_verifier(func)
     return wrapped
 
+def reset_base_component_tree() -> None:
+    """
+    Reset the base component tree to zero
 
+    (use mainly in tests)
+    """
+    global base_component_tree
+    base_component_tree = core_ui.build_base_component_tree()
 
 
 state_serialiser = StateSerialiser()
 initial_state = StreamsyncState()
-base_component_tree = ComponentTree()
-base_cmc_tree = DependentComponentTree(base_component_tree)
+base_component_tree = core_ui.build_base_component_tree()
 session_manager = SessionManager()

--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -78,6 +78,21 @@ class ComponentTreeBranch:
         self.component_tree_id = id
         self.freeze = freeze
 
+    def clone(self) -> 'ComponentTreeBranch':
+        """
+        Clone a component branch into a new one.
+
+        Streamsync uses this action when it instantiates the component tree attached to the session.
+        This ensures complete insulation of the original shaft.
+
+        >>> cloned = bmc_tree.clone()
+        :return:
+        """
+        cloned = ComponentTreeBranch(self.component_tree_id, self.freeze)
+        cloned.components = copy.copy(self.components)
+        cloned.page_counter = self.page_counter
+        return cloned
+
 
     def get_component(self, component_id: str) -> Optional[Component]:
         return self.components.get(component_id)
@@ -341,8 +356,8 @@ def build_session_component_tree(base_component_tree: ComponentTree) -> Componen
     """
     session_tree_branch = ComponentTreeBranch(Branch.session_cmc)
 
-    cmc_tree_branch = copy.copy(base_component_tree.branch(Branch.initial_cmc))
-    bmc_tree_branch = copy.copy(base_component_tree.branch(Branch.bmc))
+    cmc_tree_branch = base_component_tree.branch(Branch.initial_cmc).clone()
+    bmc_tree_branch = base_component_tree.branch(Branch.bmc).clone()
     bmc_tree_branch.freeze = True
 
     return ComponentTree([session_tree_branch, cmc_tree_branch, bmc_tree_branch])

--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -25,14 +25,14 @@ class Branch(Enum):
     Enum for the component tree branches that can be created in streamsync
 
     * bmc: builder managed component
-    * cmc: code managed component
+    * initial_cmc: code managed component
     * session: session managed component
 
     This enum should be used only in the module core_ui.py.
     """
     bmc = "bmc"
-    cmc = "cmc"
-    session = "session"
+    initial_cmc = "initial_cmc"
+    session_cmc = "session_cmc"
 
 
 class Component(BaseModel):
@@ -160,7 +160,7 @@ class ComponentTree():
         When the tree parameter is given, the component is attached to the corresponding branch.
 
         >>> component = Component(id="root", type="root", content={})
-        >>> component_tree.attach(component, tree=Branch.cmc)
+        >>> component_tree.attach(component, tree=Branch.initial_cmc)
 
         If the component is associated with a frozen branch, an exception is thrown
         """
@@ -325,7 +325,7 @@ def build_base_component_tree() -> ComponentTree:
     """
     bmc_tree_branch = ComponentTreeBranch(Branch.bmc)
     bmc_tree_branch.attach(Component(id="root", type="root", content={}))
-    cmc_tree_branch = ComponentTreeBranch(Branch.cmc)
+    cmc_tree_branch = ComponentTreeBranch(Branch.initial_cmc)
     return ComponentTree([cmc_tree_branch, bmc_tree_branch])
 
 
@@ -339,9 +339,9 @@ def build_session_component_tree(base_component_tree: ComponentTree) -> Componen
     The builder managed component, copy from base component tree, can not be modified anymore.
     The code managed component can be modified.
     """
-    session_tree_branch = ComponentTreeBranch(Branch.session)
+    session_tree_branch = ComponentTreeBranch(Branch.session_cmc)
 
-    cmc_tree_branch = copy.copy(base_component_tree.branch(Branch.cmc))
+    cmc_tree_branch = copy.copy(base_component_tree.branch(Branch.initial_cmc))
     bmc_tree_branch = copy.copy(base_component_tree.branch(Branch.bmc))
     bmc_tree_branch.freeze = True
 
@@ -369,7 +369,7 @@ def cmc_components_list(component_tree: ComponentTree) -> list:
 
     (use mainly for testing purposes)
     """
-    return list(component_tree.branch(Branch.cmc).components.values())
+    return list(component_tree.branch(Branch.initial_cmc).components.values())
 
 
 def session_components_list(component_tree: ComponentTree) -> list:
@@ -378,7 +378,7 @@ def session_components_list(component_tree: ComponentTree) -> list:
 
    (use mainly for testing purposes)
    """
-    return list(component_tree.branch(Branch.session).components.values())
+    return list(component_tree.branch(Branch.session_cmc).components.values())
 
 
 class UIError(Exception):

--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -203,7 +203,7 @@ class ComponentTree():
             try:
                 self.updated = True
                 for tree in self.tree_branches:
-                    if tree.freeze:
+                    if not tree.freeze:
                         tree.components.pop(child.id, None)
 
             except UIError:

--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -1,20 +1,38 @@
 import contextlib
+import copy
 import logging
 import uuid
 from contextvars import ContextVar
-from typing import Any, Dict, List, Optional, Union
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union, cast
 
 from pydantic import BaseModel, Field
 
 current_parent_container: ContextVar[Union["Component", None]] = \
     ContextVar("current_parent_container")
-_current_component_tree: ContextVar[Union["DependentComponentTree", None]] = \
-    ContextVar("current_component_tree", default=None)
+
 # This variable is thread safe and context safe
+_current_component_tree: ContextVar[Union["ComponentTree", None]] = \
+    ContextVar("current_component_tree", default=None)
 
 
 def generate_component_id():
     return str(uuid.uuid4())
+
+
+class Fragment(Enum):
+    """
+    Enum for the component tree fragments that can be created in streamsync
+
+    * bmc: builder managed component
+    * cmc: code managed component
+    * session: session managed component
+
+    This enum should be used only in the module core_ui.py.
+    """
+    bmc = "bmc"
+    cmc = "cmc"
+    session = "session"
 
 
 class Component(BaseModel):
@@ -42,72 +60,56 @@ class Component(BaseModel):
         current_parent_container.reset(self._token)
 
 
-class ComponentTree:
+class ComponentTreeFragment:
+    """
+    >>> bmc_tree = ComponentTreeFragment(Fragment.bmc, False)
+    """
 
-    def __init__(self, attach_root=True) -> None:
+    def __init__(self, id: Fragment, freeze: bool = False) -> None:
+        """
+
+        :param id: the id of the component tree fragment (bmc, cmc, session)
+        :param freeze: the component list can not be modified
+        """
         self.components: Dict[str, Component] = {}
+        # Page counter is required to set
+        # predefined IDs & keys for code-managed pages
+        self.page_counter = 0
+        self.component_tree_id = id
+        self.freeze = freeze
 
-        if attach_root:
-            root_component = Component(
-                id="root", type="root", content={}
-            )
-            self.attach(root_component)
 
     def get_component(self, component_id: str) -> Optional[Component]:
         return self.components.get(component_id)
 
-    def get_direct_descendents(self, parent_id: str) -> List[Component]:
-        children = list(filter(lambda c: c.parentId == parent_id,
-                               self.components.values()))
-        return children
-
-    def get_descendents(self, parent_id: str) -> List[Component]:
-        children = self.get_direct_descendents(parent_id)
-        desc = children.copy()
-        for child in children:
-            desc += self.get_descendents(child.id)
-
-        return desc
-
-    def determine_position(self, parent_id: str, is_positionless: bool = False):
-        if is_positionless:
-            return -2
-
-        children = self.get_direct_descendents(parent_id)
-        cmc_children = list(filter(lambda c: c.isCodeManaged is True, children))
-        if len(cmc_children) > 0:
-            position = \
-                max([0, max([child.position for child in cmc_children]) + 1])
-            return position
-        else:
-            return 0
-
-    def attach(self, component: Component, override=False) -> None:
+    def attach(self, component: Component) -> None:
         """
         Attaches a component to the main components dictionary of the instance.
 
         :param component: The component to be attached.
-        :type component: Component
-        :param override: If True, an existing component with the same ID will
-                         be overridden. Defaults to False.
-        :type override: bool, optional
         """
-        if (component.id in self.components) and (override is False):
-            raise RuntimeWarning(
-                f"Component with ID {component.id} already exists"
-                )
+        if self.freeze:
+            raise UIError(f"Component tree {self.component_tree_id} is frozen and cannot be modified")
+
+        if (component.id in self.components):
+            raise RuntimeWarning(f"Component with ID {component.id} already exists")
+
+        if component.type == "page" and component.id not in self.components:
+            self.page_counter += 1
+
         self.components[component.id] = component
 
     def ingest(self, serialised_components: Dict[str, Any]) -> None:
-        removed_ids = [
-            key for key in self.components
-            if key not in serialised_components
-        ]
+        if self.freeze:
+            raise UIError(f"Component tree {self.component_tree_id} is frozen and cannot be modified")
+
+        removed_ids = [key for key in self.components if key not in serialised_components]
 
         for component_id in removed_ids:
             if component_id == "root":
                 continue
             self.components.pop(component_id)
+
         for component_id, sc in serialised_components.items():
             component = Component(**sc)
             self.components[component_id] = component
@@ -116,7 +118,187 @@ class ComponentTree:
         active_components = {}
         for id, component in self.components.items():
             active_components[id] = component.to_dict()
+
         return active_components
+
+
+
+class ComponentTree():
+
+    def __init__(self, trees: List[ComponentTreeFragment]):
+        assert len(trees) > 0, "Component tree must have at least one tree fragment"
+        self.trees = trees
+        self.updated = False
+
+    @property
+    def components(self) -> Dict[str, Component]:
+        trees = reversed(self.trees)
+        all_components = {}
+        for tree in trees:
+            all_components.update(tree.components)
+        return all_components
+
+    @property
+    def page_counter(self) -> int:
+        return sum([tree.page_counter for tree in self.trees])
+
+    def get_component(self, component_id: str) -> Optional[Component]:
+        for tree in self.trees:
+            component = tree.get_component(component_id)
+            if component:
+                return component
+
+        return None
+
+    def attach(self, component: Component, tree: Optional[Fragment] = None) -> None:
+        """
+        Attach a component to the first tree fragment in the component tree.
+
+        >>> component = Component(id="root", type="root", content={})
+        >>> component_tree.attach(component)
+
+        When the tree parameter is given, the component is attached to the corresponding fragment.
+
+        >>> component = Component(id="root", type="root", content={})
+        >>> component_tree.attach(component, tree=Fragment.cmc)
+
+        If the component is associated with a frozen fragment, an exception is thrown
+        """
+        self.updated = True
+
+        _fragment = self._tree_fragment(tree)
+        if _fragment is None:
+            raise ValueError(f"Invalid tree fragment : {tree}")
+
+        cast(ComponentTreeFragment, _fragment).attach(component)
+
+    def ingest(self, serialised_components: Dict[str, Any], tree: Optional[Fragment] = None) -> None:
+        self.updated = True
+        _fragment = self._tree_fragment(tree)
+        if _fragment is None:
+            raise ValueError(f"Invalid tree fragment : {tree}")
+
+        cast(ComponentTreeFragment, _fragment).ingest(serialised_components)
+
+    def delete_component(self, component_id: str) -> None:
+        for tree in self.trees:
+            if component_id in tree.components and tree.freeze:
+                self.updated = True
+                tree.components.pop(component_id, None)
+                return
+            elif component_id in tree.components and not tree.freeze:
+                raise UIError(
+                    f"Component with ID '{component_id}' " +
+                    "is builder-managed and cannot be removed by app"
+                    )
+
+        raise KeyError(
+            f"Failed to delete component with ID {component_id}: " +
+            "no such component"
+        )
+
+    def clear_children(self, component_id: str) -> None:
+        children = self.get_descendents(component_id)
+        for child in children:
+            try:
+                self.delete_component(child.id)
+            except UIError:
+                logger = logging.getLogger("streamsync")
+                logger.warning(
+                    f"Failed to remove child with ID '{child.id}' " +
+                    f"from component with ID '{component_id}': " +
+                    "child is a builder-managed component.")
+                # This might result in multiple consecutive warnings
+                # for the same parent component, but we have to avoid "break"ing
+                # due to that the component might still have CMC children
+                self.updated = True
+                for tree in self.trees:
+                    if tree.freeze:
+                        tree.components.pop(child.id, None)
+
+
+
+    def to_dict(self) -> Dict:
+        trees = reversed(self.trees)
+        components = {}
+        for tree in trees:
+            components.update(tree.to_dict())
+
+        return components
+
+    def next_page_id(self) -> str:
+        return f"page-{self.page_counter}"
+
+    def fetch_updates(self):
+        if self.updated:
+            self.updated = False
+            return self.to_dict()
+
+        return
+
+    def determine_position(self, parent_id: str, is_positionless: bool) -> int:
+        if is_positionless:
+            return -2
+
+        children = self._get_direct_descendents(parent_id)
+        cmc_children = list(filter(lambda c: c.isCodeManaged is True, children))
+        if len(cmc_children) > 0:
+            position = \
+                max([0, max([child.position for child in cmc_children]) + 1])
+            return position
+        else:
+            return 0
+
+    def get_descendents(self, parent_id: str) -> List[Component]:
+        children = self._get_direct_descendents(parent_id)
+        desc = children.copy()
+        for child in children:
+            desc += self.get_descendents(child.id)
+
+        return desc
+
+    def fragment(self, component_id: Fragment) -> ComponentTreeFragment:
+        fragment = self._tree_fragment(component_id)
+        if fragment is None:
+            raise ValueError(f"Component tree with ID {component_id} does not exist")
+
+        return fragment
+
+    def exists(self, tree_fragment: Fragment) -> bool:
+        """
+        Checks if a component with the given ID exists in the component tree.
+
+        :param tree_fragment:
+        :return:
+        """
+        fragment = self._tree_fragment(tree_fragment)
+        return fragment is not None
+
+    def is_frozen(self, tree_fragment: Fragment) -> bool:
+        """
+        Checks if a component tree fragment is frozen.
+        """
+        fragment = self._tree_fragment(tree_fragment)
+        if fragment is None:
+            raise ValueError(f"Component tree with ID {tree_fragment} does not exist")
+
+        return fragment.freeze
+
+    def _get_direct_descendents(self, parent_id: str) -> List[Component]:
+        _all_components = self.components.values()
+        children = list(filter(lambda c: c.parentId == parent_id, _all_components))
+        return children
+
+    def _tree_fragment(self, tree_fragment: Optional[Fragment]) -> Optional[ComponentTreeFragment]:
+        if tree_fragment is None:
+            return self.trees[0]
+
+        for tree in self.trees:
+            if tree_fragment == tree.component_tree_id:
+                return tree
+
+        return None
+
 
     def get_parent(self, component_id: str) -> List[str]:
         """
@@ -139,116 +321,68 @@ class ComponentTree:
         return parents
 
 
-class DependentComponentTree(ComponentTree):
+def build_base_component_tree() -> ComponentTree:
+    """
+    Create the base component tree. This tree is used when loading streamsync.
 
-    def __init__(self, base_component_tree: ComponentTree, attach_root=False):
-        super().__init__(attach_root)
-        self.base_component_tree = base_component_tree
-
-        # Page counter is required to set
-        # predefined IDs & keys for code-managed pages
-        self.page_counter = 0
-
-    def attach(self, component: Component, override=False) -> None:
-        if component.type == "page" and component.id not in self.components:
-            self.page_counter += 1
-        return super().attach(component, override)
-
-    def get_component(self, component_id: str) -> Optional[Component]:
-        own_component_present = component_id in self.components
-        if own_component_present:
-            # If present, return own component
-            own_component = self.components.get(component_id)
-            return own_component
-
-        # Otherwise, try to obtain the base tree component
-        return self.base_component_tree.get_component(component_id)
-
-    def delete_component(self, component_id: str) -> None:
-        if component_id in self.components:
-            self.components.pop(component_id, None)
-            return
-        if component_id in self.base_component_tree.components:
-            raise UIError(
-                f"Component with ID '{component_id}' " +
-                "is builder-managed and cannot be removed by app"
-                )
-        raise KeyError(
-            f"Failed to delete component with ID {component_id}: " +
-            "no such component"
-            )
-
-    def clear_children(self, component_id: str) -> None:
-        children = self.get_descendents(component_id)
-        for child in children:
-            try:
-                self.delete_component(child.id)
-            except UIError:
-                logger = logging.getLogger("streamsync")
-                logger.warning(
-                    f"Failed to remove child with ID '{child.id}' " +
-                    f"from component with ID '{component_id}': " +
-                    "child is a builder-managed component.")
-                # This might result in multiple consecutive warnings
-                # for the same parent component, but we have to avoid "break"ing
-                # due to that the component might still have CMC children
-
-    def get_direct_descendents(self, parent_id: str) -> List[Component]:
-        base_children = self.base_component_tree.get_direct_descendents(parent_id)
-        own_children = list(filter(lambda c: c.parentId == parent_id, self.components.values()))
-        return base_children + own_children
-
-    def to_dict(self, owned_only=False) -> Dict:
-        if owned_only:
-            # If only owned components are requested,
-            # do not collect base tree components
-            active_components = {}
-        else:
-            active_components = {
-                # Collecting serialized base tree components
-                component_id: base_component.to_dict()
-                for component_id, base_component
-                in self.base_component_tree.components.items()
-            }
-        for component_id, own_component in self.components.items():
-            # Overriding base tree components with ones that belong to dependent tree
-            active_components[component_id] = own_component.to_dict()
-        return active_components
+    It contains the components in common between all users.
+    """
+    bmc_tree_fragment = ComponentTreeFragment(Fragment.bmc)
+    bmc_tree_fragment.attach(Component(id="root", type="root", content={}))
+    cmc_tree_fragment = ComponentTreeFragment(Fragment.cmc)
+    return ComponentTree([cmc_tree_fragment, bmc_tree_fragment])
 
 
-class SessionComponentTree(DependentComponentTree):
+def build_session_component_tree(base_component_tree: ComponentTree) -> ComponentTree:
+    """
+    Creates a session component tree.
 
-    def __init__(self, base_component_tree: ComponentTree, base_cmc_tree: DependentComponentTree):
-        super().__init__(base_component_tree, attach_root=False)
+    The session component tree is associated with a user session, i.e. a browser tab.
+    If the user refreshes the page, a new component tree for the session is created.
 
-        # Initialize SessionComponentTree with components from the base
-        # CMC pool, added during app initialization
-        preinitialized_components = base_cmc_tree.to_dict(owned_only=True)
-        self.ingest(preinitialized_components)
+    The builder managed component, copy from base component tree, can not be modified anymore.
+    The code managed component can be modified.
+    """
+    session_fragment = ComponentTreeFragment(Fragment.session)
 
-        preinitialized_pages = \
-            filter(lambda c: c.type == "page", self.components.values())
-        self.page_counter = len(list(preinitialized_pages))
+    cmc_tree_fragment = copy.copy(base_component_tree.fragment(Fragment.cmc))
+    bmc_tree_fragment = copy.copy(base_component_tree.fragment(Fragment.bmc))
+    bmc_tree_fragment.freeze = True
 
-        self.updated = False
+    return ComponentTree([session_fragment, cmc_tree_fragment, bmc_tree_fragment])
 
-    def attach(self, component: Component, override=False) -> None:
-        self.updated = True
-        return super().attach(component, override)
 
-    def ingest(self, serialised_components: Dict[str, Any]) -> None:
-        self.updated = True
-        return super().ingest(serialised_components)
+def injest_bmc_component_tree(component_tree: ComponentTree, components: Dict[str, Any]):
+    """
+    Updates the builder managed component tree fragment with the provided components.
+    This method is used on the event `componentUpdate`.
 
-    def delete_component(self, component_id: str) -> None:
-        self.updated = True
-        return super().delete_component(component_id)
+    >>> injest_bmc_component_tree(component_tree, {"root": {"type": "root", "content": {}})
+    """
+    assert component_tree.exists(Fragment.bmc) is True, \
+        "bmc component tree fragment does not exists in this component tree"
+    assert component_tree.is_frozen(Fragment.bmc) is False, \
+        "builder managed component tree are frozen and cannot be updated"
 
-    def fetch_updates(self):
-        if self.updated:
-            self.updated = False
-            return self.to_dict()
-        return
+    component_tree.ingest(components, tree=Fragment.bmc)
+
+
+def cmc_components_list(component_tree: ComponentTree) -> list:
+    """
+    Returns the list of code managed components in the component tree.
+
+    (use mainly for testing purposes)
+    """
+    return list(component_tree.fragment(Fragment.cmc).components.values())
+
+
+def session_components_list(component_tree: ComponentTree) -> list:
+    """
+   Returns the list of session managed components in the component tree.
+
+   (use mainly for testing purposes)
+   """
+    return list(component_tree.fragment(Fragment.session).components.values())
 
 
 class UIError(Exception):
@@ -256,7 +390,7 @@ class UIError(Exception):
 
 
 @contextlib.contextmanager
-def use_component_tree(component_tree: DependentComponentTree):
+def use_component_tree(component_tree: ComponentTree):
     """
     Declares the component tree that will be manipulated during a context.
 
@@ -273,7 +407,7 @@ def use_component_tree(component_tree: DependentComponentTree):
     _current_component_tree.reset(token)
 
 
-def current_component_tree() -> DependentComponentTree:
+def current_component_tree() -> ComponentTree:
     """
     Retrieves the component tree of the current context or the base
     one if no context has been declared.
@@ -283,6 +417,6 @@ def current_component_tree() -> DependentComponentTree:
     tree = _current_component_tree.get()
     if tree is None:
         import streamsync.core
-        return streamsync.core.base_cmc_tree
+        return streamsync.core.base_component_tree
 
     return tree

--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -181,12 +181,12 @@ class ComponentTree():
         cast(ComponentTreeBranch, _branch).ingest(serialised_components)
 
     def delete_component(self, component_id: str) -> None:
-        for tree in self.trees:
-            if component_id in tree.components and tree.freeze:
+        for tree_branch in self.trees:
+            if component_id in tree_branch.components and not tree_branch.freeze:
                 self.updated = True
-                tree.components.pop(component_id, None)
+                tree_branch.components.pop(component_id, None)
                 return
-            elif component_id in tree.components and not tree.freeze:
+            elif component_id in tree_branch.components and tree_branch.freeze:
                 raise UIError(
                     f"Component with ID '{component_id}' " +
                     "is builder-managed and cannot be removed by app"

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -4,7 +4,6 @@ from typing import Optional
 from streamsync.core_ui import (
     Component,
     ComponentTree,
-    DependentComponentTree,
     UIError,
     current_component_tree,
     current_parent_container,
@@ -48,8 +47,7 @@ class StreamsyncUI:
         return root_component
 
     @staticmethod
-    def find(component_id: str) \
-            -> Component:
+    def find(component_id: str) -> Component:
         """
         Retrieves a component by its ID from the current session's component tree.
 
@@ -175,7 +173,7 @@ def _prepare_value(value):
     return str(value)
 
 
-def _create_component(component_tree: DependentComponentTree,  component_type: str, **kwargs) -> Component:
+def _create_component(component_tree: ComponentTree, component_type: str, **kwargs) -> Component:
 
     parent_container = current_parent_container.get(None)
     if kwargs.get("id", False) is None:

--- a/src/ui/src/streamsyncTypes.ts
+++ b/src/ui/src/streamsyncTypes.ts
@@ -1,9 +1,9 @@
-import { generateCore } from "./core";
-import { generateBuilderManager } from "./builder/builderManager";
+import { generateCore } from "./core"
+import { generateBuilderManager } from "./builder/builderManager"
 
-export type Core = ReturnType<typeof generateCore>;
+export type Core = ReturnType<typeof generateCore>
 
-type ComponentId = string;
+type ComponentId = string
 
 /**
  * Basic building block of applications.

--- a/tests/backend/fixtures/core_ui_fixtures.py
+++ b/tests/backend/fixtures/core_ui_fixtures.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from streamsync.core_ui import Component, ComponentTree, ComponentTreeFragment, Fragment
+from streamsync.core_ui import Branch, Component, ComponentTree, ComponentTreeBranch
 
 
 def build_fake_component_tree(components: List[Component] = None, init_root=True):
@@ -10,7 +10,7 @@ def build_fake_component_tree(components: List[Component] = None, init_root=True
     :param components: list of components to attach
     :param init_root: create a root component
     """
-    component_tree = ComponentTree([ComponentTreeFragment(Fragment.bmc, freeze=False)])
+    component_tree = ComponentTree([ComponentTreeBranch(Branch.bmc, freeze=False)])
     if init_root:
         component_tree.attach(Component(id='root', parentId=None, type='root'))
 

--- a/tests/backend/fixtures/core_ui_fixtures.py
+++ b/tests/backend/fixtures/core_ui_fixtures.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from streamsync.core_ui import Component, ComponentTree
+from streamsync.core_ui import Component, ComponentTree, ComponentTreeFragment, Fragment
 
 
 def build_fake_component_tree(components: List[Component] = None, init_root=True):
@@ -10,7 +10,10 @@ def build_fake_component_tree(components: List[Component] = None, init_root=True
     :param components: list of components to attach
     :param init_root: create a root component
     """
-    component_tree = ComponentTree(attach_root=init_root)
+    component_tree = ComponentTree([ComponentTreeFragment(Fragment.bmc, freeze=False)])
+    if init_root:
+        component_tree.attach(Component(id='root', parentId=None, type='root'))
+
     for component in components or []:
         component_tree.attach(component)
 

--- a/tests/backend/test_ui.py
+++ b/tests/backend/test_ui.py
@@ -195,3 +195,51 @@ class TestUIManager:
             except AssertionError as exception:
                 assert str(exception) == "builder managed component tree are frozen and cannot be updated"
 
+    def test_refresh_with_should_remove_existing_children(self):
+        """
+        Verifies that context refresh with cleans up existing children of the specified component
+        """
+        # Given
+        fake_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id='section1', parentId='root', type='section'),
+            Component(id='section2', parentId='section1', type='section'),
+            Component(id='test_button', parentId='section2', type='button'),
+            Component(id='section3', parentId='root', type='section'),
+        ], init_root=True)
+
+
+        with use_component_tree(fake_component_tree):
+            ui = StreamsyncUIManager()
+
+            assert len(ui.component_tree.components) == 5
+
+            # When
+            with ui.refresh_with('section1'):
+                ui.Text({"text": "New content"}, id="new-content-1")
+
+            # Then
+            assert len(ui.component_tree.components) == 4
+
+    def test_refresh_with_should_remove_new_children(self):
+        """
+        Verifies that context refresh with cleans up existing children of the specified component
+        """
+        # Given
+        fake_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id='section1', parentId='root', type='section'),
+            Component(id='section2', parentId='section1', type='section'),
+            Component(id='test_button', parentId='section2', type='button'),
+            Component(id='section3', parentId='root', type='section'),
+        ], init_root=True)
+
+
+        with use_component_tree(fake_component_tree):
+            ui = StreamsyncUIManager()
+
+            with ui.refresh_with('section1'):
+                ui.Text({"text": "New content"}, id="new-content-1")
+
+            assert len(ui.component_tree.components) == 4
+
+            with ui.refresh_with('section1'):
+                assert len(ui.component_tree.components) == 3

--- a/tests/backend/test_ui.py
+++ b/tests/backend/test_ui.py
@@ -7,7 +7,7 @@ from streamsync.core_ui import (
     Component,
     UIError,
     cmc_components_list,
-    injest_bmc_component_tree,
+    ingest_bmc_component_tree,
     session_components_list,
     use_component_tree,
 )
@@ -26,7 +26,7 @@ def use_ui_manager_with_init_ui():
     application loads in the `ss.init_ui` context.
     """
     core.reset_base_component_tree()
-    injest_bmc_component_tree(core.base_component_tree, sc)
+    ingest_bmc_component_tree(core.base_component_tree, sc)
     with use_component_tree(core.base_component_tree):
         yield StreamsyncUIManager()
 
@@ -38,7 +38,7 @@ def use_ui_manager_with_event_handler():
     an event handler context.
     """
     core.reset_base_component_tree()
-    injest_bmc_component_tree(core.base_component_tree, sc)
+    ingest_bmc_component_tree(core.base_component_tree, sc)
     session = ss.session_manager.get_new_session()
     with use_component_tree(session.session_component_tree):
         yield StreamsyncUIManager()
@@ -191,7 +191,7 @@ class TestUIManager:
     def test_update_bmc_component_tree_should_not_work_from_event_handlers(self):
         with use_ui_manager_with_event_handler() as ui:
             try:
-                injest_bmc_component_tree(ui.component_tree, sc)
+                ingest_bmc_component_tree(ui.component_tree, sc)
             except AssertionError as exception:
                 assert str(exception) == "builder managed component tree are frozen and cannot be updated"
 

--- a/tests/backend/test_ui.py
+++ b/tests/backend/test_ui.py
@@ -2,44 +2,59 @@ import contextlib
 import json
 
 import streamsync as ss
-from streamsync.core_ui import Component, ComponentTree, UIError, use_component_tree
+from streamsync import core
+from streamsync.core_ui import (
+    Component,
+    UIError,
+    cmc_components_list,
+    injest_bmc_component_tree,
+    session_components_list,
+    use_component_tree,
+)
 from streamsync.ui import StreamsyncUIManager
 
 from backend.fixtures import core_ui_fixtures
 from tests.backend import test_app_dir
 
-sc = None
 with open(test_app_dir / "ui.json", "r") as f:
     sc = json.load(f).get("components")
 
+@contextlib.contextmanager
+def use_ui_manager_with_init_ui():
+    """
+    create a Streamsync UIManager such that streamsync retrieves it when an
+    application loads in the `ss.init_ui` context.
+    """
+    core.reset_base_component_tree()
+    injest_bmc_component_tree(core.base_component_tree, sc)
+    with use_component_tree(core.base_component_tree):
+        yield StreamsyncUIManager()
+
 
 @contextlib.contextmanager
-def use_new_ss_session():
+def use_ui_manager_with_event_handler():
+    """
+    create a Streamsync UIManager such that streamsync retrieves it in
+    an event handler context.
+    """
+    core.reset_base_component_tree()
+    injest_bmc_component_tree(core.base_component_tree, sc)
     session = ss.session_manager.get_new_session()
-    session.session_component_tree.ingest(sc)
-    yield session
-
-
-@contextlib.contextmanager
-def use_ui_manager():
-    with use_new_ss_session() as session:
-        with use_component_tree(session.session_component_tree):
-            yield StreamsyncUIManager()
+    with use_component_tree(session.session_component_tree):
+        yield StreamsyncUIManager()
 
 
 class TestComponentTree:
 
-    ct = ComponentTree()
-
     def test_ingest(self) -> None:
-        with use_new_ss_session() as session:
-            d = session.session_component_tree.to_dict()
+        with use_ui_manager_with_init_ui() as ui:
+            d = ui.component_tree.to_dict()
             assert d.get(
                 "84378aea-b64c-49a3-9539-f854532279ee").get("type") == "header"
 
     def test_descendents(self) -> None:
-        with use_new_ss_session() as session:
-            desc = session.session_component_tree.get_descendents("root")
+        with use_ui_manager_with_init_ui() as ui:
+            desc = ui.component_tree.get_descendents("root")
             desc_ids = [x.id for x in desc]
             assert "84378aea-b64c-49a3-9539-f854532279ee" in desc_ids
             assert "bb4d0e86-619e-4367-a180-be28ab6059f4" in desc_ids
@@ -49,7 +64,7 @@ class TestComponentTree:
 class TestUIManager:
 
     def test_find_component(self):
-        with use_ui_manager() as ui:
+        with use_ui_manager_with_init_ui() as ui:
             # Verify that the find method correctly retrieves a component by its ID
             expected_id = "84378aea-b64c-49a3-9539-f854532279ee"
             with ui.find(expected_id) as found_component:
@@ -57,7 +72,7 @@ class TestUIManager:
                 assert found_component.id == expected_id
 
     def test_find_component_no_context(self):
-        with use_ui_manager() as ui:
+        with use_ui_manager_with_init_ui() as ui:
             # Verify that the find method correctly retrieves a component by its ID
             expected_id = "84378aea-b64c-49a3-9539-f854532279ee"
             found_component = ui.find(expected_id)
@@ -67,7 +82,7 @@ class TestUIManager:
     def test_assert_in_container_context(self):
         # Verify the context assertion for creating components within a container
         # First, successfully create a component within a container context
-        with use_ui_manager() as ui:
+        with use_ui_manager_with_init_ui() as ui:
             with ui.root:
                 passed = False
                 try:
@@ -86,21 +101,23 @@ class TestUIManager:
             assert raised, "Creating a component outside of a container context should raise an UIError"
 
     def test_column_container_creation(self):
-        with use_ui_manager() as ui:
+        with use_ui_manager_with_init_ui() as ui:
             with ui.ColumnContainer(id="test_container") as container:
                 assert container.type == 'columns'
                 assert container.id == "test_container"
-                assert container in ui.component_tree.components.values()
+                assert container in ui.component_tree.components.values() # visible in component list
+                assert container in cmc_components_list(ui.component_tree) # present in the cmc component fragment
 
     def test_column_container_creation_no_context(self):
-        with use_ui_manager() as ui:
+        with use_ui_manager_with_init_ui() as ui:
             container = ui.ColumnContainer(id="test_container")
             assert container.type == 'columns'
             assert container.id == "test_container"
-            assert container in ui.component_tree.components.values()
+            assert container in ui.component_tree.components.values()  # visible in component list
+            assert container in cmc_components_list(ui.component_tree)  # present in the cmc component fragment
 
     def test_column_container_creation_no_id(self):
-        with use_ui_manager() as ui:
+        with use_ui_manager_with_init_ui() as ui:
             with ui.ColumnContainer() as container:
                 assert container.type == 'columns'
                 assert container.id is not None
@@ -108,14 +125,14 @@ class TestUIManager:
                 assert container.id in ui.component_tree.components.keys()
 
     def test_column_creation(self):
-        with use_ui_manager() as ui:
+        with use_ui_manager_with_init_ui() as ui:
             with ui.Column(id="test_column") as column:
                 assert column.type == 'column'
                 assert column.id == "test_column"
                 assert column in ui.component_tree.components.values()
 
     def test_text_creation(self):
-        with use_ui_manager() as ui:
+        with use_ui_manager_with_init_ui() as ui:
             with ui.Column(id="test_column") as column:
                 text_content = "Hello World"
                 text_component = ui.Text({"text": text_content}, id="test_text")
@@ -124,6 +141,8 @@ class TestUIManager:
             assert text_component.id == "test_text"
             assert text_component.parentId == column.id
             assert text_component in ui.component_tree.components.values()
+            assert text_component in cmc_components_list(ui.component_tree)  # present in the cmc component fragment
+
 
     def test_parent_should_return_the_first_level_parent(self):
         """
@@ -158,3 +177,21 @@ class TestUIManager:
             id = StreamsyncUIManager().parent('test_button', 2)
             # Then
             assert id == 'section1'
+
+
+    def test_text_creation_should_create_component_in_session_when_triggered_on_event_handler(self):
+        with use_ui_manager_with_event_handler() as ui:
+            with ui.Column(id="test_column"):
+                text_component = ui.Text({"text": "Hello World"})
+
+            assert text_component in ui.component_tree.components.values()
+            assert text_component in session_components_list(ui.component_tree)  # present in the session component fragment
+            assert text_component not in cmc_components_list(ui.component_tree)
+
+    def test_update_bmc_component_tree_should_not_work_from_event_handlers(self):
+        with use_ui_manager_with_event_handler() as ui:
+            try:
+                injest_bmc_component_tree(ui.component_tree, sc)
+            except AssertionError as exception:
+                assert str(exception) == "builder managed component tree are frozen and cannot be updated"
+


### PR DESCRIPTION
This is a refactoring proposal to make the notion of component tree simpler. This refactoring removes the 3 distinct classes that inherit from each other to represent the 3 trees. It removes cascading inheritance and method overloading.

There is a single class `ComponentTree` class that can combine fragments. One fragment for BMC, one for CMC, one for SMC. A fragment can be frozen to lock its contents. Fragments are an instance of the same `ComponentTreeFragment` class.

The application contains 2 tree construction methods. `build_base_component_tree` which builds the tree the application needs upon loading with a fragment for BMCs and CMCs. `build_session_component_tree` builds a tree dedicated to the user session with 3 fragments, one fragment for SMCs, one for CMCs and a frozen fragment for BMCs. The fragments are copied to separate them from the base representation.



I added in the tests, 2 distinct contexts, one to represent a ui manager when streamsync application is loading and one to represent a ui manager in an event handler.

