### PR TITLE
feat: capture the component that trigger an event in context

### DIFF
--- a/docs/docs/backend-driven-ui.md
+++ b/docs/docs/backend-driven-ui.md
@@ -62,6 +62,18 @@ with ui.find("column-container"):
 ```
 If the component couldn't be found, the method raises a `RuntimeError`.
 
+### `parent` method
+
+`ui.parent(component_id: str, level: int = 1)` gives access to the id to parents at higher levels.
+
+```python
+container = ui.parent('my-text') # first parent id
+
+container = ui.parent('my-text', 3) # level 3 parent id
+with ui.find(container):
+	...
+```
+
 ### Component methods
 
 UI manager contains methods linked to each frontend component. For example, in previous code snippets we provide a `ui.Text` method, which is used for creating [Text components](https://www.streamsync.cloud/component-list.html#text).

--- a/docs/docs/event-handlers.md
+++ b/docs/docs/event-handlers.md
@@ -159,3 +159,23 @@ In the example above, `fetch_data()` is an asynchronous function that retrieves 
 
 You can use any awaitable object within an async event handler. This includes the output of any function defined with `async def`, or objects with an `__await__` method. This makes it easy to integrate with asynchronous libraries and frameworks.
 
+## Context
+
+The `context` argument provides additional information about the event. For example, if the event 
+was triggered by a _Button_, the `context` will include target field that contains the id of the button.
+
+```py
+def handle_click(state, context: dict):
+	last_source_of_click = context['target']
+	state["last_source_of_click"] = last_source_of_click
+```
+
+The repeater components have additional fields in the context, such as defined in `keyVariable` and `valueVariable`.
+
+```py
+def handle_repeater_click(state, context: dict):
+	key = context['keyVariable']
+	state['repeater_content'][key]['last_action'] = 'Clicked' 
+```
+
+more information in [repeater chapter](repeater.md)

--- a/src/streamsync/core.py
+++ b/src/streamsync/core.py
@@ -988,6 +988,9 @@ class Evaluator:
             context[key_variable] = repeater_items[instance_number][0]
             context[value_variable] = repeater_items[instance_number][1]
 
+        if len(instance_path) > 0:
+            context['target'] = instance_path[-1]['componentId']
+            
         return context
 
     def set_state(self, expr: str, instance_path: InstancePath, value: Any) -> None:

--- a/src/streamsync/core_ui.py
+++ b/src/streamsync/core_ui.py
@@ -117,6 +117,26 @@ class ComponentTree:
             active_components[id] = component.to_dict()
         return active_components
 
+    def get_parent(self, component_id: str) -> List[str]:
+        """
+        Returns the list of parents, from the first to the highest level (root normally)
+
+        :param component_id:
+        :return:
+        """
+        components = self.components.values()
+        parents = []
+        current_node: Optional[str] = component_id
+        while current_node is not None:
+            for component in components:
+                if component.id == current_node:
+                    if component.parentId is not None:
+                        parents.append(component.parentId)
+
+                    current_node = component.parentId
+
+        return parents
+
 
 class DependentComponentTree(ComponentTree):
 
@@ -183,6 +203,7 @@ class DependentComponentTree(ComponentTree):
             # Overriding base tree components with ones that belong to dependent tree
             active_components[component_id] = own_component.to_dict()
         return active_components
+
 
 
 class SessionComponentTree(DependentComponentTree):

--- a/src/streamsync/ui_manager.py
+++ b/src/streamsync/ui_manager.py
@@ -76,6 +76,22 @@ class StreamsyncUI:
         return component
 
     @staticmethod
+    def parent(component_id: str, level: int = 1) -> Optional[str]:
+        """
+        Retrieves the ID of the top-level parent.
+
+        :param component_id:
+        :param level:
+        :return:
+        """
+        component_tree = current_component_tree()
+        parents_container = component_tree.get_parent(component_id)
+        if len(parents_container) < level - 1:
+            return None
+
+        return parents_container[level - 1]
+
+    @staticmethod
     def create_container_component(component_type: str, **kwargs) -> Component:
         component_tree = current_component_tree()
         container = _create_component(component_tree, component_type, **kwargs)

--- a/tests/backend/fixtures/core_ui_fixtures.py
+++ b/tests/backend/fixtures/core_ui_fixtures.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from streamsync.core_ui import Component, ComponentTree
+
+
+def build_fake_component_tree(components: List[Component] = None, init_root=True):
+    """
+    Builds a fake component tree for testing purposes.
+
+    :param components: list of components to attach
+    :param init_root: create a root component
+    """
+    component_tree = ComponentTree(attach_root=init_root)
+    for component in components or []:
+        component_tree.attach(component)
+
+    return component_tree

--- a/tests/backend/test_core.py
+++ b/tests/backend/test_core.py
@@ -23,8 +23,10 @@ from streamsync.core import (
     StateSerialiserException,
     StreamsyncState,
 )
+from streamsync.core_ui import Component
 from streamsync.ss_types import StreamsyncEvent
 
+from backend.fixtures import core_ui_fixtures
 from tests.backend import test_app_dir
 
 raw_state_dict = {
@@ -838,6 +840,56 @@ class TestEvaluator:
         assert e.evaluate_expression("features.eyes", instance_path) == "green"
         assert e.evaluate_expression("best_feature", instance_path) == "eyes"
         assert e.evaluate_expression("features[best_feature]", instance_path) == "green"
+
+    def test_get_context_data_should_return_the_target_of_event(self) -> None:
+        """
+        Test that the target of the event is correctly returned by the get_context_data method
+
+        Here we reproduce a click on a button
+        """
+        # Given
+        st = StreamsyncState({})
+        ct = core_ui_fixtures.build_fake_component_tree([
+            Component(id="button1", parentId="root", type="button")
+        ], init_root=True)
+
+        e = Evaluator(st, ct)
+
+        # When
+        context = e.get_context_data([
+            {"componentId": "root", "instanceNumber": 0},
+            {"componentId": "button1", "instanceNumber": 0}
+        ])
+
+        # Then
+        assert context.get("target") == "button1"
+
+    def test_get_context_data_should_return_the_repeater_position_and_the_target_inside_the_repeater(self) -> None:
+        """
+        Test that the repeater position and target of the event is correctly returned by the get_context_data method
+
+        Here we reproduce a click on a button
+        """
+        # Given
+        st = StreamsyncState({})
+        ct = core_ui_fixtures.build_fake_component_tree([
+            Component(id="repeater1", parentId="root", type="repeater", content={'keyVariable': 'item', 'valueVariable': 'value', 'repeaterObject': json.dumps({'a': 'A', 'b': 'B'})}),
+            Component(id="button1", parentId="repeater1", type="button")
+        ], init_root=True)
+
+        e = Evaluator(st, ct)
+
+        # When
+        context = e.get_context_data([
+            {"componentId": "root", "instanceNumber": 0},
+            {"componentId": "repeater1", "instanceNumber": 0},
+            {"componentId": "button1", "instanceNumber": 1}
+        ])
+
+        # Then
+        assert context.get("target") == "button1"
+        assert context.get("item") == "b"
+        assert context.get("value") == "B"
 
 
 class TestSessionManager:

--- a/tests/backend/test_ui.py
+++ b/tests/backend/test_ui.py
@@ -2,9 +2,10 @@ import contextlib
 import json
 
 import streamsync as ss
-from streamsync.core_ui import ComponentTree, UIError, use_component_tree
+from streamsync.core_ui import Component, ComponentTree, UIError, use_component_tree
 from streamsync.ui import StreamsyncUIManager
 
+from backend.fixtures import core_ui_fixtures
 from tests.backend import test_app_dir
 
 sc = None
@@ -123,3 +124,37 @@ class TestUIManager:
             assert text_component.id == "test_text"
             assert text_component.parentId == column.id
             assert text_component in ui.component_tree.components.values()
+
+    def test_parent_should_return_the_first_level_parent(self):
+        """
+        Test that the parent method returns the first level parent of a component
+        """
+        # Given
+        fake_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id='test_button', parentId='root', type='button'),
+        ], init_root=True)
+
+        with use_component_tree(fake_component_tree):
+            # When
+            id = StreamsyncUIManager().parent('test_button', 1)
+
+            # Then
+            assert id == 'root'
+
+    def test_parent_should_return_the_2_level_parent(self):
+        """
+        Test that the parent with level 2 as argument returns the 2 level parent of a component
+        """
+        # Given
+        fake_component_tree = core_ui_fixtures.build_fake_component_tree([
+            Component(id='section1', parentId='root', type='section'),
+            Component(id='section2', parentId='section1', type='section'),
+            Component(id='test_button', parentId='section2', type='button'),
+            Component(id='section3', parentId='root', type='section'),
+        ], init_root=True)
+
+        with use_component_tree(fake_component_tree):
+            # When
+            id = StreamsyncUIManager().parent('test_button', 2)
+            # Then
+            assert id == 'section1'


### PR DESCRIPTION
On a click or an event, a developer can consult the identifier at the origin of the event from the context. This allows it to adapt the behavior of its event handler or to retrieve the parent to add interface components.

```python
def increment(state, context):
    print(context['target'])
```

```python
def increment(state, ui, context):
   container = ui.parent(context['target'])
    with ui.find(container):
      pass
```

```python
def increment(state, ui, context):
   container = ui.parent(context['target'], level=3) # third parent
    with ui.find(container):
      pass
```

### definition of done

* add a documentation section about `Context` into [EventHandler](https://www.streamsync.cloud/event-handlers.html)