### PR TITLE
fix: import for State, for using State Schema, is missing in streamsync highlevel import

### DIFF
--- a/src/streamsync/__init__.py
+++ b/src/streamsync/__init__.py
@@ -4,7 +4,7 @@ from typing import Union, Optional, Dict, Any, Type, TypeVar, cast
 from streamsync.core import (BytesWrapper, Config, FileWrapper, Readable,
                              base_component_tree, base_cmc_tree, initial_state,
                              session_manager, session_verifier)
-from streamsync.core import Readable, FileWrapper, BytesWrapper, Config, StreamsyncState
+from streamsync.core import Readable, FileWrapper, BytesWrapper, Config, StreamsyncState, State
 from streamsync.core import new_initial_state, base_component_tree, session_manager, session_verifier
 from streamsync.ui import StreamsyncUIManager
 


### PR DESCRIPTION
fix #369 

You have to write ``ss.core.State`` instead of ``ss.State``

```python
import streamsync as ss

class MyappSchema(ss.core.State):
    title: str

class AppSchema(ss.StreamsyncState):
    my_app: MyappSchema
    counter: int

initial_state = ss.init_state({
    "counter": 0,
    "my_app": {
        "title": "Nested value"
    }
}, schema=AppSchema)
```