### PR TITLE
docs: add workflow to trigger mintlify in base repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  trigger-mintlify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger mintlify workflow
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DOCS_WORKFLOW_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'anant-writer',
+              repo: 'docs',
+              workflow_id: 'mintlify-action.yml',
+              ref: 'main',
+            });


### PR DESCRIPTION
This PR creates a workflow that triggers the `mintlify-action` workflow in anant-writer/docs

The reason this isn't part of the `ci.yml` workflow is because `ci.yml` runs on pushes to `master` _and_ `dev`, but this should only run on `master`. We could probably still place it in `ci.yml` and add an `if` statement to skip the step if on `dev`, but I figured this was simpler. Lmk if you'd prefer the alternative

Remaining work:
- [ ] create a PAT that has write access to the workflows in anant-writer/docs (not this repo)
- [ ] add the PAT as a repository secret with the name `DOCS_WORKFLOW_TOKEN` (link https://github.com/streamsync-cloud/streamsync/settings/secrets/actions)